### PR TITLE
Pr/collab/18419

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -467,7 +467,7 @@ GEM
     ruby-progressbar (1.13.0)
     ruby-rc4 (0.1.5)
     ruby2_keywords (0.0.5)
-    ruby_smb (3.2.5)
+    ruby_smb (3.2.6)
       bindata
       openssl-ccm
       openssl-cmac

--- a/LICENSE_GEMS
+++ b/LICENSE_GEMS
@@ -169,7 +169,7 @@ ruby-prof, 1.4.2, "Simplified BSD"
 ruby-progressbar, 1.13.0, MIT
 ruby-rc4, 0.1.5, MIT
 ruby2_keywords, 0.0.5, "ruby, Simplified BSD"
-ruby_smb, 3.2.5, "New BSD"
+ruby_smb, 3.2.6, "New BSD"
 rubyntlm, 0.6.3, MIT
 rubyzip, 2.3.2, "Simplified BSD"
 sawyer, 0.9.2, MIT

--- a/lib/msf/core/exploit/remote/dcerpc/kerberos_authentication.rb
+++ b/lib/msf/core/exploit/remote/dcerpc/kerberos_authentication.rb
@@ -45,7 +45,7 @@ module Msf::Exploit::Remote::DCERPC::KerberosAuthentication
   def build_ap_rep(session_key, sequence_number)
     pvno = Rex::Proto::Kerberos::Model::VERSION
     msg_type = Rex::Proto::Kerberos::Model::AP_REP
-    ctime = Time.now.utc 
+    ctime = Time.now.utc
     cusec = ctime&.usec
 
     encrypted_part = Rex::Proto::Kerberos::Model::EncApRepPart.new(
@@ -66,7 +66,7 @@ module Msf::Exploit::Remote::DCERPC::KerberosAuthentication
     )
   end
 
-  def auth_provider_complete_handshake(response, options)    
+  def auth_provider_complete_handshake(response, options)
       @kerberos_authenticator.validate_response!(response.auth_value, accept_incomplete: true)
       gss_api = OpenSSL::ASN1.decode(response.auth_value)
       security_blob = ::RubySMB::Gss.asn1dig(gss_api, 0, 2, 0)&.value
@@ -84,9 +84,7 @@ module Msf::Exploit::Remote::DCERPC::KerberosAuthentication
           ])
         ], 1, :CONTEXT_SPECIFIC).to_der
 
-      alter_ctx = RubySMB::Dcerpc::Bind.new(options)
-      # Alter context (3rd message) is identical to Bind requests by definition
-      alter_ctx.pdu_header.ptype = RubySMB::Dcerpc::PTypes::ALTER_CONTEXT
+      alter_ctx = RubySMB::Dcerpc::AlterContext.new(options)
       alter_ctx.pdu_header.call_id = @call_id
 
       add_auth_verifier(alter_ctx, wrapped_ap_rep)
@@ -99,7 +97,7 @@ module Msf::Exploit::Remote::DCERPC::KerberosAuthentication
         raise RubySMB::Dcerpc::Error::BindError # raise the more context-specific BindError
       end
 
-      self.krb_encryptor = @kerberos_authenticator.get_message_encryptor(ap_rep_enc_part.subkey, 
+      self.krb_encryptor = @kerberos_authenticator.get_message_encryptor(ap_rep_enc_part.subkey,
                                                                                   @client_sequence_number,
                                                                                   server_sequence_number)
       # Set the session key value on the parent class - needed for decrypting attribute values in e.g. DRSR


### PR DESCRIPTION
Adds two changes:

1. Switches to using the new AlterContext definition
2. Bumps RubySMB to 3.2.6 to pull in the upstream changes from the now merged PR in rapid7/ruby_smb#253