### PR TITLE
Fixing platform selection for SSH bind shell

### DIFF
--- a/lib/msf/base/sessions/ssh_command_shell_bind.rb
+++ b/lib/msf/base/sessions/ssh_command_shell_bind.rb
@@ -242,6 +242,8 @@ module Msf::Sessions
         extend(Msf::Sessions::WindowsEscaping)
       elsif Metasploit::Framework::Ssh::Platform.is_posix(@platform)
         extend(Msf::Sessions::UnixEscaping)
+      else
+        raise NotImplementedError
       end
 
       # if the platform is known, it was recovered by communicating with the device, so skip verification, also not all


### PR DESCRIPTION
This PR adds a fix for proposed comment. Just adding `else` branch with exception for unknown platform.